### PR TITLE
Support system integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,18 @@ Additionally, the following libraries are loaded for Linux:
 - `libudev.so.1` (if joysticks are enabled)
 - `libpulse.so.0` (if audio is enabled)
 
+You may pass any number of the following flags to `zig build` when building wio
+(or any wio-based project) to add runtime paths for libraries installed on your
+system (or marked as dependencies in a package manager):
+
+- `-fsys=x11`
+- `-fsys=gl`
+- `-fsys=wayland`
+- `-fsys=egl`
+- `-fsys=udev`
+- `-fsys=pulse`
+- `-fsys=vulkan`
+
 ## Platform-specific API
 
 The following variables and fields may be considered part of the public API

--- a/build.zig
+++ b/build.zig
@@ -37,6 +37,31 @@ pub fn build(b: *std.Build) void {
             }
             module.addCSourceFile(.{ .file = b.path("src/unix/wayland.c") });
             if (tag == .openbsd) module.linkSystemLibrary("sndio", .{});
+
+            if (b.systemIntegrationOption("x11", .{})) {
+                module.linkSystemLibrary("x11", .{});
+                module.linkSystemLibrary("xcursor", .{});
+            }
+
+            if (b.systemIntegrationOption("gl", .{})) module.linkSystemLibrary("gl", .{});
+
+            if (b.systemIntegrationOption("wayland", .{})) {
+                module.linkSystemLibrary("wayland-client", .{});
+                module.linkSystemLibrary("xkbcommon", .{});
+                module.linkSystemLibrary("decor-0", .{});
+            }
+
+            if (b.systemIntegrationOption("egl", .{})) {
+                module.linkSystemLibrary("wayland-egl", .{});
+                module.linkSystemLibrary("egl", .{});
+            }
+
+            if (b.systemIntegrationOption("udev", .{}))
+                module.linkSystemLibrary("libudev", .{});
+
+            if (b.systemIntegrationOption("pulse", .{})) module.linkSystemLibrary("pulse", .{});
+
+            if (b.systemIntegrationOption("vulkan", .{})) module.linkSystemLibrary("vulkan", .{});
         },
         else => {
             if (target.result.isWasm()) {


### PR DESCRIPTION
This will make it easier to properly add dependencies when building for distros and package managers such as Nix and Homebrew. Unlike regular build options, system integration options are propagated down to users' projects. Even though the resulting binary doesn't link the libraries themselves, their runtime paths are still added.