### PR TITLE
Add software rendering support for Linux and Windows

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -15,7 +15,9 @@ pub fn build(b: *std.Build) !void {
     var enable_joystick = false;
     var enable_audio = false;
 
-    const features = b.option([]const u8, "features", "List of enabled features (default: opengl,joystick,audio) (available: vulkan)") orelse "opengl,joystick,audio";
+    var enable_software = false;
+
+    const features = b.option([]const u8, "features", "List of enabled features (default: opengl,joystick,audio) (available: vulkan,software)") orelse "opengl,joystick,audio";
     var feature_iter = std.mem.tokenizeScalar(u8, features, ',');
     while (feature_iter.next()) |feature| {
         if (std.mem.eql(u8, feature, "opengl")) {
@@ -26,6 +28,8 @@ pub fn build(b: *std.Build) !void {
             enable_joystick = true;
         } else if (std.mem.eql(u8, feature, "audio")) {
             enable_audio = true;
+        } else if (std.mem.eql(u8, feature, "software")) {
+            enable_software = true;
         } else {
             @panic("option 'features' is invalid");
         }
@@ -52,6 +56,7 @@ pub fn build(b: *std.Build) !void {
     options.addOption(bool, "vulkan", enable_vulkan);
     options.addOption(bool, "joystick", enable_joystick);
     options.addOption(bool, "audio", enable_audio);
+    options.addOption(bool, "software", enable_software);
     options.addOption(bool, "x11", enable_x11);
     options.addOption(bool, "wayland", enable_wayland);
     options.addOption(bool, "system_integration", system_integration);
@@ -61,6 +66,7 @@ pub fn build(b: *std.Build) !void {
     if (enable_vulkan) module.addCMacro("WIO_VULKAN", "");
     if (enable_joystick) module.addCMacro("WIO_JOYSTICK", "");
     if (enable_audio) module.addCMacro("WIO_AUDIO", "");
+    if (enable_software) module.addCMacro("WIO_SOFTWARE", "");
 
     if (b.option(bool, "win32_manifest", "Embed application manifest (default: true)") orelse true) {
         module.addWin32ResourceFile(.{ .file = b.path("src/win32.rc") });
@@ -76,6 +82,9 @@ pub fn build(b: *std.Build) !void {
             if (enable_opengl) {
                 module.linkSystemLibrary("gdi32", .{});
                 module.linkSystemLibrary("opengl32", .{});
+            }
+            if (enable_software and !enable_opengl) {
+                module.linkSystemLibrary("gdi32", .{});
             }
             if (enable_joystick) {
                 module.linkSystemLibrary("hid", .{});
@@ -207,4 +216,21 @@ pub fn build(b: *std.Build) !void {
 
     const run_step = b.step("run", "Run the app");
     run_step.dependOn(&run_cmd.step);
+
+    const sw_mod = b.createModule(.{
+        .root_source_file = b.path("example/software.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    sw_mod.addImport("wio", module);
+
+    const sw_exe = b.addExecutable(.{
+        .name = "software",
+        .root_module = sw_mod,
+        .use_llvm = if (system_integration) null else true,
+    });
+    const run_sw_cmd = b.addRunArtifact(sw_exe);
+
+    const run_sw_step = b.step("run-sw", "Run the software renderer example");
+    run_sw_step.dependOn(&run_sw_cmd.step);
 }

--- a/example/software.zig
+++ b/example/software.zig
@@ -1,0 +1,56 @@
+const std = @import("std");
+const wio = @import("wio");
+
+var window: wio.Window = undefined;
+var maybe_buf: ?wio.SoftwareBuffer = null;
+var size: wio.Size = .{ .width = 0, .height = 0 };
+var t: u32 = 0;
+
+pub fn main() !void {
+    var debug_allocator = std.heap.DebugAllocator(.{}).init;
+    defer _ = debug_allocator.deinit();
+
+    try wio.init(debug_allocator.allocator(), .{});
+    defer wio.deinit();
+
+    window = try wio.createWindow(.{ .title = "software", .scale = 1 });
+    defer window.destroy();
+
+    while (true) {
+        wio.update();
+        while (window.getEvent()) |event| {
+            switch (event) {
+                .close => {
+                    if (maybe_buf) |*buf| buf.destroy();
+                    return;
+                },
+                .framebuffer => |fb| {
+                    if (maybe_buf) |*buf| buf.destroy();
+                    maybe_buf = null;
+                    if (fb.width > 0 and fb.height > 0) {
+                        maybe_buf = try window.createSoftwareBuffer(fb);
+                        size = fb;
+                    }
+                },
+                else => {},
+            }
+        }
+        if (maybe_buf) |*buf| {
+            render(buf.getPixels());
+            buf.present();
+            t +%= 1;
+        }
+        wio.wait(.{ .timeout_ns = std.time.ns_per_s / 60 });
+    }
+}
+
+fn render(pixels: []u32) void {
+    const w: u32 = size.width;
+    const h: u32 = size.height;
+    for (0..h) |y| {
+        for (0..w) |x| {
+            const v = @as(u32, @intCast(x)) ^ @as(u32, @intCast(y)) ^ t;
+            pixels[y * w + x] = ((v & 0xff) << 16) | (((v >> 1) & 0xff) << 8) | ((v >> 2) & 0xff);
+        }
+    }
+}

--- a/src/haiku.zig
+++ b/src/haiku.zig
@@ -200,11 +200,32 @@ pub const Window = struct {
         self.opengl.vsync = (interval > 0);
     }
 
+    pub fn createSoftwareBuffer(self: *Window, size: wio.Size) !*SoftwareBuffer {
+        _ = self;
+        _ = size;
+        return error.Unexpected;
+    }
+
     fn pushEvent(self: *Window, event: wio.Event) void {
         self.events_mutex.lock();
         defer self.events_mutex.unlock();
         self.events.push(event);
         wait_event.set();
+    }
+};
+
+pub const SoftwareBuffer = struct {
+    pub fn destroy(self: *SoftwareBuffer) void {
+        _ = self;
+    }
+
+    pub fn getPixels(self: *SoftwareBuffer) []u32 {
+        _ = self;
+        return &.{};
+    }
+
+    pub fn present(self: *SoftwareBuffer) void {
+        _ = self;
     }
 };
 

--- a/src/macos.zig
+++ b/src/macos.zig
@@ -315,6 +315,27 @@ pub const Window = struct {
             surface,
         );
     }
+
+    pub fn createSoftwareBuffer(self: *Window, size: wio.Size) !*SoftwareBuffer {
+        _ = self;
+        _ = size;
+        return error.Unexpected;
+    }
+};
+
+pub const SoftwareBuffer = struct {
+    pub fn destroy(self: *SoftwareBuffer) void {
+        _ = self;
+    }
+
+    pub fn getPixels(self: *SoftwareBuffer) []u32 {
+        _ = self;
+        return &.{};
+    }
+
+    pub fn present(self: *SoftwareBuffer) void {
+        _ = self;
+    }
 };
 
 pub fn glGetProcAddress(name: [*:0]const u8) ?*const anyopaque {

--- a/src/null.zig
+++ b/src/null.zig
@@ -115,6 +115,27 @@ pub const Window = struct {
         _ = surface;
         return 0;
     }
+
+    pub fn createSoftwareBuffer(self: *Window, size: wio.Size) !*SoftwareBuffer {
+        _ = self;
+        _ = size;
+        return error.Unexpected;
+    }
+};
+
+pub const SoftwareBuffer = struct {
+    pub fn destroy(self: *SoftwareBuffer) void {
+        _ = self;
+    }
+
+    pub fn getPixels(self: *SoftwareBuffer) []u32 {
+        _ = self;
+        return &.{};
+    }
+
+    pub fn present(self: *SoftwareBuffer) void {
+        _ = self;
+    }
 };
 
 pub fn glGetProcAddress(name: [:0]const u8) ?*const anyopaque {

--- a/src/unix.zig
+++ b/src/unix.zig
@@ -338,6 +338,13 @@ pub const Window = union {
             .wayland => return self.wayland.createSurface(instance, allocator, surface),
         }
     }
+
+    pub fn createSoftwareBuffer(self: *Window, size: wio.Size) !SoftwareBuffer {
+        switch (active) {
+            .x11 => return .{ .x11 = try self.x11.createSoftwareBuffer(size) },
+            .wayland => return .{ .wayland = try self.wayland.createSoftwareBuffer(size) },
+        }
+    }
 };
 
 pub fn glGetProcAddress(name: [*:0]const u8) ?*const anyopaque {
@@ -364,3 +371,29 @@ pub const AudioDeviceIterator = audio.AudioDeviceIterator;
 pub const AudioDevice = audio.AudioDevice;
 pub const AudioOutput = audio.AudioOutput;
 pub const AudioInput = audio.AudioInput;
+
+pub const SoftwareBuffer = union {
+    x11: *x11.SoftwareBuffer,
+    wayland: *wayland.SoftwareBuffer,
+
+    pub fn destroy(self: *SoftwareBuffer) void {
+        switch (active) {
+            .x11 => self.x11.destroy(),
+            .wayland => self.wayland.destroy(),
+        }
+    }
+
+    pub fn getPixels(self: *SoftwareBuffer) []u32 {
+        switch (active) {
+            .x11 => return self.x11.getPixels(),
+            .wayland => return self.wayland.getPixels(),
+        }
+    }
+
+    pub fn present(self: *SoftwareBuffer) void {
+        switch (active) {
+            .x11 => self.x11.present(),
+            .wayland => self.wayland.present(),
+        }
+    }
+};

--- a/src/unix/wayland.zig
+++ b/src/unix/wayland.zig
@@ -94,6 +94,7 @@ var libEGL: DynLib = undefined;
 pub var display: *h.wl_display = undefined;
 var registry: *h.wl_registry = undefined;
 var compositor: ?*h.wl_compositor = null;
+var shm: ?*h.wl_shm = null;
 var seat: ?*h.wl_seat = null;
 var keyboard: ?*h.wl_keyboard = null;
 var pointer: ?*h.wl_pointer = null;
@@ -248,6 +249,7 @@ pub fn deinit() void {
 }
 
 fn destroyProxies() void {
+    if (build_options.software) if (shm) |_| h.wl_shm_destroy(shm);
     if (data_source) |_| h.wl_data_source_destroy(data_source);
     if (data_offer) |_| h.wl_data_offer_destroy(data_offer);
     if (data_device) |_| h.wl_data_device_destroy(data_device);
@@ -620,6 +622,53 @@ pub const Window = struct {
         }
     }
 
+    pub fn createSoftwareBuffer(self: *Window, size: wio.Size) !*SoftwareBuffer {
+        const wl_shm = shm orelse return error.Unexpected;
+        const self_buf = try internal.allocator.create(SoftwareBuffer);
+        errdefer internal.allocator.destroy(self_buf);
+
+        const byte_size = @as(usize, size.width) * @as(usize, size.height) * @sizeOf(u32);
+
+        const fd = try std.posix.memfd_create("wio", 0);
+        errdefer std.posix.close(fd);
+
+        try std.posix.ftruncate(fd, byte_size);
+
+        const mapped = try std.posix.mmap(
+            null,
+            byte_size,
+            std.posix.PROT.READ | std.posix.PROT.WRITE,
+            .{ .TYPE = .SHARED },
+            fd,
+            0,
+        );
+        errdefer std.posix.munmap(mapped);
+
+        const pool = h.wl_shm_create_pool(wl_shm, fd, @intCast(byte_size)) orelse return error.Unexpected;
+        defer h.wl_shm_pool_destroy(pool);
+
+        const buffer = h.wl_shm_pool_create_buffer(
+            pool,
+            0,
+            size.width,
+            size.height,
+            @intCast(@as(usize, size.width) * @sizeOf(u32)),
+            h.WL_SHM_FORMAT_XRGB8888,
+        ) orelse return error.Unexpected;
+
+        const pixels: [*]u32 = @ptrCast(@alignCast(mapped.ptr));
+
+        self_buf.* = .{
+            .buffer = buffer,
+            .surface = self.surface,
+            .pixels = pixels[0 .. @as(usize, size.width) * @as(usize, size.height)],
+            .mapped = mapped,
+            .fd = fd,
+            .size = size,
+        };
+        return self_buf;
+    }
+
     fn applyCursor(self: *Window) void {
         if (self.cursor_mode == .normal) {
             if (cursor_shape_device) |_| {
@@ -639,6 +688,33 @@ pub const Window = struct {
                 self.locked_pointer = h.zwp_pointer_constraints_v1_lock_pointer(pointer_constraints, self.surface, pointer, null, h.ZWP_POINTER_CONSTRAINTS_V1_LIFETIME_PERSISTENT);
             }
         }
+    }
+};
+
+pub const SoftwareBuffer = struct {
+    buffer: *h.wl_buffer,
+    surface: *h.wl_surface,
+    pixels: []u32,
+    mapped: []align(std.heap.page_size_min) u8,
+    fd: std.posix.fd_t,
+    size: wio.Size,
+
+    pub fn destroy(self: *SoftwareBuffer) void {
+        h.wl_buffer_destroy(self.buffer);
+        std.posix.munmap(self.mapped);
+        std.posix.close(self.fd);
+        internal.allocator.destroy(self);
+    }
+
+    pub fn getPixels(self: *SoftwareBuffer) []u32 {
+        return self.pixels;
+    }
+
+    pub fn present(self: *SoftwareBuffer) void {
+        h.wl_surface_attach(self.surface, self.buffer, 0, 0);
+        h.wl_surface_damage(self.surface, 0, 0, @intCast(self.size.width), @intCast(self.size.height));
+        h.wl_surface_commit(self.surface);
+        _ = c.wl_display_roundtrip(display);
     }
 };
 
@@ -669,6 +745,8 @@ fn registryGlobal(_: ?*anyopaque, _: ?*h.wl_registry, name: u32, interface_ptr: 
     const interface = std.mem.sliceTo(interface_ptr, 0);
     if (std.mem.eql(u8, interface, "wl_compositor")) {
         compositor = @ptrCast(h.wl_registry_bind(registry, name, &h.wl_compositor_interface, @min(version, 3)));
+    } else if (build_options.software and std.mem.eql(u8, interface, "wl_shm")) {
+        shm = @ptrCast(h.wl_registry_bind(registry, name, &h.wl_shm_interface, @min(version, 1)));
     } else if (std.mem.eql(u8, interface, "wl_seat")) {
         seat = @ptrCast(h.wl_registry_bind(registry, name, &h.wl_seat_interface, @min(version, 4)));
         _ = h.wl_seat_add_listener(seat, &seat_listener, null);

--- a/src/unix/x11.zig
+++ b/src/unix/x11.zig
@@ -59,6 +59,8 @@ var imports: extern struct {
     XCheckTypedWindowEvent: *const @TypeOf(h.XCheckTypedWindowEvent),
     XCreateColormap: *const @TypeOf(h.XCreateColormap),
     XFreeColormap: *const @TypeOf(h.XFreeColormap),
+    XCreateImage: *const @TypeOf(h.XCreateImage),
+    XPutImage: *const @TypeOf(h.XPutImage),
     glXQueryExtensionsString: *const @TypeOf(h.glXQueryExtensionsString),
     glXGetProcAddress: *const @TypeOf(h.glXGetProcAddress),
     glXChooseFBConfig: *const @TypeOf(h.glXChooseFBConfig),
@@ -544,6 +546,64 @@ pub const Window = struct {
             allocator,
             surface,
         );
+    }
+
+    pub fn createSoftwareBuffer(self: *Window, size: wio.Size) !*SoftwareBuffer {
+        const self_buf = try internal.allocator.create(SoftwareBuffer);
+        errdefer internal.allocator.destroy(self_buf);
+
+        const pixel_count = @as(usize, size.width) * @as(usize, size.height);
+        const pixels = try internal.allocator.alloc(u32, pixel_count);
+        errdefer internal.allocator.free(pixels);
+
+        const image = c.XCreateImage(
+            display,
+            h.DefaultVisual(display, h.DefaultScreen(display)),
+            24,
+            h.ZPixmap,
+            0,
+            @ptrCast(pixels.ptr),
+            size.width,
+            size.height,
+            32,
+            0,
+        ) orelse return internal.logUnexpected("XCreateImage");
+
+        const gc = c.XCreateGC(display, self.window, 0, null);
+
+        self_buf.* = .{
+            .image = image,
+            .gc = gc,
+            .xwindow = self.window,
+            .pixels = pixels,
+            .size = size,
+        };
+        return self_buf;
+    }
+};
+
+pub const SoftwareBuffer = struct {
+    image: *h.XImage,
+    gc: h.GC,
+    xwindow: h.Window,
+    pixels: []u32,
+    size: wio.Size,
+
+    pub fn destroy(self: *SoftwareBuffer) void {
+        self.image.data = null;
+        _ = c.XFree(self.image);
+        _ = c.XFreeGC(display, self.gc);
+        internal.allocator.free(self.pixels);
+        internal.allocator.destroy(self);
+    }
+
+    pub fn getPixels(self: *SoftwareBuffer) []u32 {
+        return self.pixels;
+    }
+
+    pub fn present(self: *SoftwareBuffer) void {
+        _ = c.XPutImage(display, self.xwindow, self.gc, self.image, 0, 0, 0, 0, self.size.width, self.size.height);
+        _ = c.XFlush(display);
     }
 };
 

--- a/src/wasm.zig
+++ b/src/wasm.zig
@@ -136,6 +136,27 @@ pub const Window = struct {
     pub fn swapBuffers(_: *Window) void {}
 
     pub fn swapInterval(_: *Window, _: i32) void {}
+
+    pub fn createSoftwareBuffer(self: *Window, size: wio.Size) !*SoftwareBuffer {
+        _ = self;
+        _ = size;
+        return error.Unexpected;
+    }
+};
+
+pub const SoftwareBuffer = struct {
+    pub fn destroy(self: *SoftwareBuffer) void {
+        _ = self;
+    }
+
+    pub fn getPixels(self: *SoftwareBuffer) []u32 {
+        _ = self;
+        return &.{};
+    }
+
+    pub fn present(self: *SoftwareBuffer) void {
+        _ = self;
+    }
 };
 
 pub fn glGetProcAddress(_: [*:0]const u8) ?*const anyopaque {

--- a/src/win32.zig
+++ b/src/win32.zig
@@ -525,6 +525,39 @@ pub const Window = struct {
         );
     }
 
+    pub fn createSoftwareBuffer(self: *Window, size: wio.Size) !*SoftwareBuffer {
+        const self_buf = try internal.allocator.create(SoftwareBuffer);
+        errdefer internal.allocator.destroy(self_buf);
+
+        const dc = w.CreateCompatibleDC(null) orelse return logLastError("CreateCompatibleDC");
+        errdefer _ = w.DeleteDC(dc);
+
+        var info = std.mem.zeroes(w.BITMAPINFO);
+        info.bmiHeader.biSize = @sizeOf(w.BITMAPINFOHEADER);
+        info.bmiHeader.biWidth = size.width;
+        info.bmiHeader.biHeight = -@as(i32, size.height);
+        info.bmiHeader.biPlanes = 1;
+        info.bmiHeader.biBitCount = 32;
+        info.bmiHeader.biCompression = w.BI_RGB;
+
+        var bits: ?*anyopaque = null;
+        const bitmap = w.CreateDIBSection(dc, &info, w.DIB_RGB_COLORS, &bits, null, 0) orelse return logLastError("CreateDIBSection");
+        errdefer _ = w.DeleteObject(bitmap);
+        _ = w.SelectObject(dc, bitmap);
+
+        const pixel_count = @as(usize, size.width) * @as(usize, size.height);
+        const pixels: [*]u32 = @ptrCast(@alignCast(bits.?));
+
+        self_buf.* = .{
+            .dc = dc,
+            .bitmap = bitmap,
+            .pixels = pixels[0..pixel_count],
+            .size = size,
+            .hwnd = self.window,
+        };
+        return self_buf;
+    }
+
     fn isFullscreen(self: *Window) bool {
         return (w.GetWindowLongPtrW(self.window, w.GWL_STYLE) & w.WS_OVERLAPPEDWINDOW != w.WS_OVERLAPPEDWINDOW);
     }
@@ -534,6 +567,30 @@ pub const Window = struct {
         _ = w.GetClientRect(self.window, &rect);
         _ = w.MapWindowPoints(self.window, w.HWND_DESKTOP, @ptrCast(&rect), 2);
         _ = w.ClipCursor(&rect);
+    }
+};
+
+pub const SoftwareBuffer = struct {
+    dc: w.HDC,
+    bitmap: w.HBITMAP,
+    pixels: []u32,
+    size: wio.Size,
+    hwnd: w.HWND,
+
+    pub fn destroy(self: *SoftwareBuffer) void {
+        _ = w.DeleteObject(self.bitmap);
+        _ = w.DeleteDC(self.dc);
+        internal.allocator.destroy(self);
+    }
+
+    pub fn getPixels(self: *SoftwareBuffer) []u32 {
+        return self.pixels;
+    }
+
+    pub fn present(self: *SoftwareBuffer) void {
+        const dc = w.GetDC(self.hwnd);
+        defer _ = w.ReleaseDC(self.hwnd, dc);
+        _ = w.BitBlt(dc, 0, 0, self.size.width, self.size.height, self.dc, 0, 0, w.SRCCOPY);
     }
 };
 

--- a/src/wio.zig
+++ b/src/wio.zig
@@ -190,6 +190,28 @@ pub const Window = struct {
         assertFeature(.vulkan);
         return self.backend.createSurface(instance, allocator, surface);
     }
+
+    pub fn createSoftwareBuffer(self: *Window, size: Size) !SoftwareBuffer {
+        assertFeature(.software);
+        return .{ .backend = try self.backend.createSoftwareBuffer(size) };
+    }
+};
+
+pub const SoftwareBuffer = struct {
+    backend: @typeInfo(@typeInfo(@TypeOf(backend.Window.createSoftwareBuffer)).@"fn".return_type.?).error_union.payload,
+
+    pub fn destroy(self: *SoftwareBuffer) void {
+        self.backend.destroy();
+    }
+
+    /// Pixels are XRGB8888 (stored as u32 with layout 0x00RRGGBB on little-endian).
+    pub fn getPixels(self: *SoftwareBuffer) []u32 {
+        return self.backend.getPixels();
+    }
+
+    pub fn present(self: *SoftwareBuffer) void {
+        self.backend.present();
+    }
 };
 
 /// Must be called on the thread where the context is current.


### PR DESCRIPTION
Add software rendering via a new SoftwareBuffer API (createSoftwareBuffer, getPixels, present, destroy). Implemented on Wayland (wl_shm/mmap), X11 (XPutImage), and Win32 (DIBSection/BitBlt).

Stubbed on macOS, Haiku, and WASM.

example:

`main.zig`
```zig
const std = @import("std");
const wio = @import("wio");

var window: wio.Window = undefined;
var maybe_buf: ?wio.SoftwareBuffer = null;
var size: wio.Size = .{ .width = 0, .height = 0 };
var t: u32 = 0;

pub fn main() !void {
    var debug_allocator = std.heap.DebugAllocator(.{}).init;
    defer _ = debug_allocator.deinit();

    try wio.init(debug_allocator.allocator(), .{});
    defer wio.deinit();

    window = try wio.createWindow(.{ .title = "swdemo", .scale = 1 });
    defer window.destroy();

    while (true) {
        wio.update();
        while (window.getEvent()) |event| {
            switch (event) {
                .close => {
                    if (maybe_buf) |*buf| buf.destroy();
                    return;
                },
                .framebuffer => |fb| {
                    if (maybe_buf) |*buf| buf.destroy();
                    maybe_buf = null;
                    if (fb.width > 0 and fb.height > 0) {
                        maybe_buf = try window.createSoftwareBuffer(fb);
                        size = fb;
                    }
                },
                else => {},
            }
        }
        if (maybe_buf) |*buf| {
            render(buf.getPixels());
            buf.present();
            t +%= 1;
        }
        wio.wait(.{ .timeout_ns = std.time.ns_per_s / 60 });
    }
}

fn render(pixels: []u32) void {
    const w: u32 = size.width;
    const h: u32 = size.height;
    for (0..h) |y| {
        for (0..w) |x| {
            const v = @as(u32, @intCast(x)) ^ @as(u32, @intCast(y)) ^ t;
            pixels[y * w + x] = ((v & 0xff) << 16) | (((v >> 1) & 0xff) << 8) | ((v >> 2) & 0xff);
        }
    }
}
```

<img width="770" height="638" alt="image" src="https://github.com/user-attachments/assets/333bf039-cfd1-4651-b504-01041f7ad18e" />
