### PR TITLE
Set app_id on wayland and x11

### DIFF
--- a/src/unix/wayland.zig
+++ b/src/unix/wayland.zig
@@ -61,6 +61,7 @@ var imports: extern struct {
     libdecor_state_free: *const @TypeOf(h.libdecor_state_free),
     libdecor_frame_commit: *const @TypeOf(h.libdecor_frame_commit),
     libdecor_frame_set_title: *const @TypeOf(h.libdecor_frame_set_title),
+    libdecor_frame_set_app_id: *const @TypeOf(h.libdecor_frame_set_app_id),
     libdecor_frame_set_maximized: *const @TypeOf(h.libdecor_frame_set_maximized),
     libdecor_frame_unset_maximized: *const @TypeOf(h.libdecor_frame_unset_maximized),
     libdecor_frame_set_fullscreen: *const @TypeOf(h.libdecor_frame_set_fullscreen),
@@ -312,6 +313,12 @@ pub fn createWindow(options: wio.CreateWindowOptions) !*Window {
 
     self.setTitle(options.title);
     self.setMode(options.mode);
+
+    {
+        const id = try internal.allocator.dupeZ(u8, options.app_id orelse options.title);
+        defer internal.allocator.free(id);
+        c.libdecor_frame_set_app_id(self.frame, id.ptr);
+    }
 
     h.wl_surface_commit(surface);
     while (!self.configured) {

--- a/src/unix/x11.zig
+++ b/src/unix/x11.zig
@@ -54,6 +54,7 @@ var imports: extern struct {
     XGrabPointer: *const @TypeOf(h.XGrabPointer),
     XUngrabPointer: *const @TypeOf(h.XUngrabPointer),
     XWarpPointer: *const @TypeOf(h.XWarpPointer),
+    XSetClassHint: *const @TypeOf(h.XSetClassHint),
     XSetSelectionOwner: *const @TypeOf(h.XSetSelectionOwner),
     XConvertSelection: *const @TypeOf(h.XConvertSelection),
     XCheckTypedWindowEvent: *const @TypeOf(h.XCheckTypedWindowEvent),
@@ -321,6 +322,13 @@ pub fn createWindow(options: wio.CreateWindowOptions) !*Window {
 
     self.setTitle(options.title);
     self.setMode(options.mode);
+
+    {
+        const id = try internal.allocator.dupeZ(u8, options.app_id orelse options.title);
+        defer internal.allocator.free(id);
+        var class_hint = h.XClassHint{ .res_name = @constCast(id.ptr), .res_class = @constCast(id.ptr) };
+        _ = c.XSetClassHint(display, window, &class_hint);
+    }
 
     self.events.push(.visible);
     self.events.push(.{ .scale = scale });

--- a/src/wio.zig
+++ b/src/wio.zig
@@ -90,6 +90,9 @@ pub const RelativePosition = struct { x: i16, y: i16 };
 
 pub const CreateWindowOptions = struct {
     title: []const u8 = "wio",
+    /// Application identifier used as the window class (X11) or app_id (Wayland).
+    /// Defaults to the title if empty.
+    app_id: ?[]const u8 = null,
     mode: WindowMode = .normal,
 
     size: Size = .{ .width = 640, .height = 480 },


### PR DESCRIPTION
`wio` is now used as an additional gui backend for the [flow control](https://github.com/neurocyte/flow) editor. We have an option to set the window class / app id and added this to `wio` to make that work.