### PR TITLE
window: drop events

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -60,6 +60,8 @@ pub fn build(b: *std.Build) !void {
             }
 
             module.linkSystemLibrary("user32", .{});
+            module.linkSystemLibrary("ole32", .{});
+            module.linkSystemLibrary("shell32", .{});
             if (enable_framebuffer or enable_opengl) {
                 module.linkSystemLibrary("gdi32", .{});
             }
@@ -69,9 +71,6 @@ pub fn build(b: *std.Build) !void {
             if (enable_joystick) {
                 module.linkSystemLibrary("hid", .{});
                 module.linkSystemLibrary(if (target.result.cpu.arch.isX86()) "xinput9_1_0" else "xinput1_4", .{});
-            }
-            if (enable_audio) {
-                module.linkSystemLibrary("ole32", .{});
             }
         },
         .macos => {

--- a/demo/src/main.zig
+++ b/demo/src/main.zig
@@ -104,6 +104,7 @@ fn loop() !bool {
                 }
             },
             .drop_file => |path| allocator.free(path),
+            .drop_text => |text| allocator.free(text),
             else => try actionEvent(event),
         }
     }
@@ -157,7 +158,9 @@ fn logEvent(event: wio.Event) void {
         .scroll_vertical, .scroll_horizontal => |value| std.log.info("{s} {d}", .{ @tagName(event), value }),
         .touch => |touch| std.log.info("touch {}: ({},{})", .{ touch.id, touch.x, touch.y }),
         .touch_end => |touch| std.log.info("touch {}: {s}", .{ touch.id, if (touch.ignore) "ignore" else "end" }),
+        .drop_position => |pos| std.log.info("drop_position ({},{})", .{ pos.x, pos.y }),
         .drop_file => |path| std.log.info("drop_file: {s}", .{path}),
+        .drop_text => |text| std.log.info("drop_text: {s}", .{text}),
         else => std.log.info("{s}", .{@tagName(event)}),
     }
 }

--- a/demo/src/main.zig
+++ b/demo/src/main.zig
@@ -103,8 +103,11 @@ fn loop() !bool {
                     gl.viewport(0, 0, size.width, size.height);
                 }
             },
-            .drop_file => |path| allocator.free(path),
-            .drop_text => |text| allocator.free(text),
+            .drop_complete => {
+                const data = window.getDropData();
+                for (data.files) |path| std.log.info("drop_file: {s}", .{path});
+                if (data.text) |text| std.log.info("drop_text: {s}", .{text});
+            },
             else => try actionEvent(event),
         }
     }
@@ -159,8 +162,6 @@ fn logEvent(event: wio.Event) void {
         .touch => |touch| std.log.info("touch {}: ({},{})", .{ touch.id, touch.x, touch.y }),
         .touch_end => |touch| std.log.info("touch {}: {s}", .{ touch.id, if (touch.ignore) "ignore" else "end" }),
         .drop_position => |pos| std.log.info("drop_position ({},{})", .{ pos.x, pos.y }),
-        .drop_file => |path| std.log.info("drop_file: {s}", .{path}),
-        .drop_text => |text| std.log.info("drop_text: {s}", .{text}),
         else => std.log.info("{s}", .{@tagName(event)}),
     }
 }

--- a/demo/src/main.zig
+++ b/demo/src/main.zig
@@ -104,7 +104,8 @@ fn loop() !bool {
                 }
             },
             .drop_complete => {
-                const data = window.getDropData();
+                const data = window.getDropData(allocator);
+                defer data.free(allocator);
                 for (data.files) |path| std.log.info("drop_file: {s}", .{path});
                 if (data.text) |text| std.log.info("drop_text: {s}", .{text});
             },

--- a/demo/src/main.zig
+++ b/demo/src/main.zig
@@ -103,6 +103,7 @@ fn loop() !bool {
                     gl.viewport(0, 0, size.width, size.height);
                 }
             },
+            .drop_file => |path| allocator.free(path),
             else => try actionEvent(event),
         }
     }
@@ -156,6 +157,7 @@ fn logEvent(event: wio.Event) void {
         .scroll_vertical, .scroll_horizontal => |value| std.log.info("{s} {d}", .{ @tagName(event), value }),
         .touch => |touch| std.log.info("touch {}: ({},{})", .{ touch.id, touch.x, touch.y }),
         .touch_end => |touch| std.log.info("touch {}: {s}", .{ touch.id, if (touch.ignore) "ignore" else "end" }),
+        .drop_file => |path| std.log.info("drop_file: {s}", .{path}),
         else => std.log.info("{s}", .{@tagName(event)}),
     }
 }

--- a/src/android.zig
+++ b/src/android.zig
@@ -168,7 +168,7 @@ pub const Window = struct {
         java.env.*.*.CallVoidMethod.?(java.env, java.activity, java.setClipboardText, text_j);
     }
 
-    pub fn getDropData(_: *Window) wio.DropData {
+    pub fn getDropData(_: *Window, _: std.mem.Allocator) wio.DropData {
         return .{ .files = &.{}, .text = null };
     }
 

--- a/src/android.zig
+++ b/src/android.zig
@@ -168,6 +168,10 @@ pub const Window = struct {
         java.env.*.*.CallVoidMethod.?(java.env, java.activity, java.setClipboardText, text_j);
     }
 
+    pub fn getDropData(_: *Window) wio.DropData {
+        return .{ .files = &.{}, .text = null };
+    }
+
     pub fn getClipboardText(_: *Window, allocator: std.mem.Allocator) ?[]u8 {
         const text_j = java.env.*.*.CallObjectMethod.?(java.env, java.activity, java.getClipboardText) orelse return null;
         defer java.env.*.*.DeleteLocalRef.?(java.env, text_j);

--- a/src/haiku.cpp
+++ b/src/haiku.cpp
@@ -3,6 +3,7 @@
 #include <OpenGLKit.h>
 #include <DeviceKit.h>
 #include <MediaKit.h>
+#include <StorageKit.h>
 
 extern "C" {
     void wioClose(void *);
@@ -17,14 +18,20 @@ extern "C" {
     void wioMouse(void *, uint16, uint16);
     void wioScroll(void *, float, float);
     void wioAudioOutputWrite(void *, void *, size_t);
+    void wioDropBegin(void *);
+    void wioDropPosition(void *, uint16, uint16);
+    void wioDropFile(void *, const char *, size_t);
+    void wioDropText(void *, const char *, size_t);
+    void wioDropComplete(void *);
 }
 
 class WioWindow : public BWindow {
 private:
     void *zig;
+    bool dropping;
 
 public:
-    WioWindow(void *zig, BRect frame, const char *title) : BWindow(frame, title, B_TITLED_WINDOW, 0) {
+    WioWindow(void *zig, BRect frame, const char *title) : BWindow(frame, title, B_TITLED_WINDOW, 0), dropping(false) {
         this->zig = zig;
 #ifdef WIO_FRAMEBUFFER
         AddChild(new BView(Bounds(), "wio", B_FOLLOW_ALL_SIDES, 0));
@@ -94,6 +101,18 @@ public:
                         wioMouse(zig, where.x, where.y);
                     }
                 }
+                {
+                    BMessage drag_msg;
+                    if (message->FindMessage("be:drag_message", &drag_msg) == B_OK) {
+                        if (!dropping) {
+                            dropping = true;
+                            wioDropBegin(zig);
+                        }
+                        wioDropPosition(zig, (uint16)where.x, (uint16)where.y);
+                    } else if (dropping) {
+                        dropping = false;
+                    }
+                }
                 break;
             }
             case B_MOUSE_WHEEL_CHANGED: {
@@ -103,6 +122,22 @@ public:
                 wioScroll(zig, y, x);
                 break;
             }
+        }
+
+        if (message->WasDropped()) {
+            if (!dropping) wioDropBegin(zig);
+            dropping = false;
+            entry_ref ref;
+            for (int32 i = 0; message->FindRef("refs", i, &ref) == B_OK; i++) {
+                BPath path(&ref);
+                if (path.Path() != NULL) wioDropFile(zig, path.Path(), strlen(path.Path()));
+            }
+            const void *text;
+            ssize_t len;
+            if (message->FindData("text/plain", B_MIME_TYPE, &text, &len) == B_OK) {
+                wioDropText(zig, (const char *)text, (size_t)len);
+            }
+            wioDropComplete(zig);
         }
 
         if (dispatch_parent) {

--- a/src/haiku.cpp
+++ b/src/haiku.cpp
@@ -138,6 +138,7 @@ public:
                 wioDropText(zig, (const char *)text, (size_t)len);
             }
             wioDropComplete(zig);
+            dispatch_parent = false;
         }
 
         if (dispatch_parent) {

--- a/src/haiku.cpp
+++ b/src/haiku.cpp
@@ -29,9 +29,10 @@ class WioWindow : public BWindow {
 private:
     void *zig;
     bool dropping;
+    bool drop_began;
 
 public:
-    WioWindow(void *zig, BRect frame, const char *title) : BWindow(frame, title, B_TITLED_WINDOW, 0), dropping(false) {
+    WioWindow(void *zig, BRect frame, const char *title) : BWindow(frame, title, B_TITLED_WINDOW, 0), dropping(false), drop_began(false) {
         this->zig = zig;
 #ifdef WIO_FRAMEBUFFER
         AddChild(new BView(Bounds(), "wio", B_FOLLOW_ALL_SIDES, 0));
@@ -106,7 +107,10 @@ public:
                     if (message->FindMessage("be:drag_message", &drag_msg) == B_OK) {
                         if (!dropping) {
                             dropping = true;
-                            wioDropBegin(zig);
+                            if (!drop_began) {
+                                drop_began = true;
+                                wioDropBegin(zig);
+                            }
                         }
                         wioDropPosition(zig, (uint16)where.x, (uint16)where.y);
                     } else if (dropping) {
@@ -125,8 +129,9 @@ public:
         }
 
         if (message->WasDropped()) {
-            if (!dropping) wioDropBegin(zig);
+            if (!drop_began) wioDropBegin(zig);
             dropping = false;
+            drop_began = false;
             entry_ref ref;
             for (int32 i = 0; message->FindRef("refs", i, &ref) == B_OK; i++) {
                 BPath path(&ref);

--- a/src/haiku.zig
+++ b/src/haiku.zig
@@ -143,8 +143,13 @@ pub const Window = struct {
     buttons: std.StaticBitSet(5) = .initEmpty(),
     text: bool = false,
     opengl: if (build_options.opengl) struct { context: ?*BGLView = null, vsync: bool = false } else struct {} = .{},
+    drop_files: std.ArrayListUnmanaged([]const u8) = .empty,
+    drop_text: ?[]const u8 = null,
 
     pub fn destroy(self: *Window) void {
+        for (self.drop_files.items) |f| internal.allocator.free(f);
+        self.drop_files.deinit(internal.allocator);
+        if (self.drop_text) |t| internal.allocator.free(t);
         wioDestroyWindow(self.window);
         self.events.deinit();
         internal.allocator.destroy(self);
@@ -195,6 +200,10 @@ pub const Window = struct {
 
     pub fn setClipboardText(_: *Window, text: []const u8) void {
         wioSetClipboardText(text.ptr, text.len);
+    }
+
+    pub fn getDropData(self: *Window) wio.DropData {
+        return .{ .files = self.drop_files.items, .text = self.drop_text };
     }
 
     pub fn getClipboardText(_: *Window, allocator: std.mem.Allocator) ?[]u8 {
@@ -476,6 +485,34 @@ export fn wioMouse(self: *Window, x: u16, y: u16) void {
 export fn wioScroll(self: *Window, vertical: f32, horizontal: f32) void {
     if (vertical != 0) self.pushEvent(.{ .scroll_vertical = vertical });
     if (horizontal != 0) self.pushEvent(.{ .scroll_horizontal = horizontal });
+}
+
+export fn wioDropBegin(self: *Window) void {
+    for (self.drop_files.items) |f| internal.allocator.free(f);
+    self.drop_files.clearRetainingCapacity();
+    if (self.drop_text) |t| internal.allocator.free(t);
+    self.drop_text = null;
+    self.pushEvent(.drop_begin);
+}
+
+export fn wioDropPosition(self: *Window, x: u16, y: u16) void {
+    self.pushEvent(.{ .drop_position = .{ .x = x, .y = y } });
+}
+
+export fn wioDropFile(self: *Window, ptr: [*]const u8, len: usize) void {
+    const path = internal.allocator.dupe(u8, ptr[0..len]) catch return;
+    self.drop_files.append(internal.allocator, path) catch {
+        internal.allocator.free(path);
+    };
+}
+
+export fn wioDropText(self: *Window, ptr: [*]const u8, len: usize) void {
+    if (self.drop_text) |t| internal.allocator.free(t);
+    self.drop_text = internal.allocator.dupe(u8, ptr[0..len]) catch null;
+}
+
+export fn wioDropComplete(self: *Window) void {
+    self.pushEvent(.drop_complete);
 }
 
 fn wioAudioOutputWrite(data: *const anyopaque, buffer: [*]f32, size: usize) callconv(.c) void {

--- a/src/haiku.zig
+++ b/src/haiku.zig
@@ -202,8 +202,8 @@ pub const Window = struct {
         wioSetClipboardText(text.ptr, text.len);
     }
 
-    pub fn getDropData(self: *Window) wio.DropData {
-        return .{ .files = self.drop_files.items, .text = self.drop_text };
+    pub fn getDropData(self: *Window, allocator: std.mem.Allocator) wio.DropData {
+        return wio.DropData.dupe(allocator, self.drop_files.items, self.drop_text) catch .{ .files = &.{}, .text = null };
     }
 
     pub fn getClipboardText(_: *Window, allocator: std.mem.Allocator) ?[]u8 {

--- a/src/macos.zig
+++ b/src/macos.zig
@@ -278,6 +278,10 @@ pub const Window = struct {
         wioSetClipboardText(text.ptr, text.len);
     }
 
+    pub fn getDropData(_: *Window) wio.DropData {
+        return .{ .files = &.{}, .text = null };
+    }
+
     pub fn getClipboardText(_: *Window, allocator: std.mem.Allocator) ?[]u8 {
         var len: usize = undefined;
         const text = wioGetClipboardText(&allocator, &len) orelse return null;

--- a/src/macos.zig
+++ b/src/macos.zig
@@ -278,7 +278,7 @@ pub const Window = struct {
         wioSetClipboardText(text.ptr, text.len);
     }
 
-    pub fn getDropData(_: *Window) wio.DropData {
+    pub fn getDropData(_: *Window, _: std.mem.Allocator) wio.DropData {
         return .{ .files = &.{}, .text = null };
     }
 

--- a/src/null.zig
+++ b/src/null.zig
@@ -93,7 +93,7 @@ pub const Window = struct {
         _ = text;
     }
 
-    pub fn getDropData(_: *Window) wio.DropData {
+    pub fn getDropData(_: *Window, _: std.mem.Allocator) wio.DropData {
         return .{ .files = &.{}, .text = null };
     }
 

--- a/src/null.zig
+++ b/src/null.zig
@@ -93,6 +93,10 @@ pub const Window = struct {
         _ = text;
     }
 
+    pub fn getDropData(_: *Window) wio.DropData {
+        return .{ .files = &.{}, .text = null };
+    }
+
     pub fn getClipboardText(self: *Window, allocator: std.mem.Allocator) ?[]u8 {
         _ = self;
         _ = allocator;

--- a/src/unix.zig
+++ b/src/unix.zig
@@ -317,6 +317,13 @@ pub const Window = union {
         }
     }
 
+    pub fn getDropData(self: *Window) wio.DropData {
+        switch (active) {
+            .x11 => return self.x11.getDropData(),
+            .wayland => return self.wayland.getDropData(),
+        }
+    }
+
     pub fn createFramebuffer(self: *Window, size: wio.Size) !Framebuffer {
         switch (active) {
             .x11 => return .{ .x11 = try self.x11.createFramebuffer(size) },

--- a/src/unix.zig
+++ b/src/unix.zig
@@ -317,10 +317,10 @@ pub const Window = union {
         }
     }
 
-    pub fn getDropData(self: *Window) wio.DropData {
+    pub fn getDropData(self: *Window, allocator: std.mem.Allocator) wio.DropData {
         switch (active) {
-            .x11 => return self.x11.getDropData(),
-            .wayland => return self.wayland.getDropData(),
+            .x11 => return self.x11.getDropData(allocator),
+            .wayland => return self.wayland.getDropData(allocator),
         }
     }
 

--- a/src/unix/wayland.zig
+++ b/src/unix/wayland.zig
@@ -401,6 +401,8 @@ pub const Window = struct {
         surface: h.EGLSurface = null,
         context: h.EGLContext = null,
     } else struct {} = .{},
+    drop_files: std.ArrayListUnmanaged([]const u8) = .empty,
+    drop_text: ?[]const u8 = null,
 
     pub fn destroy(self: *Window) void {
         if (pointer_focus == self) pointer_focus = null;
@@ -430,7 +432,14 @@ pub const Window = struct {
         _ = c.wl_display_roundtrip(display);
 
         self.events.deinit();
+        for (self.drop_files.items) |f| internal.allocator.free(f);
+        self.drop_files.deinit(internal.allocator);
+        if (self.drop_text) |t| internal.allocator.free(t);
         internal.allocator.destroy(self);
+    }
+
+    pub fn getDropData(self: *Window) wio.DropData {
+        return .{ .files = self.drop_files.items, .text = self.drop_text };
     }
 
     pub fn getEvent(self: *Window) ?wio.Event {
@@ -1179,7 +1188,13 @@ fn dataDeviceEnter(_: ?*anyopaque, _: ?*h.wl_data_device, serial: u32, surface: 
         }
     }
 
-    if (drag_window) |window| window.events.push(.drop_begin);
+    if (drag_window) |window| {
+        for (window.drop_files.items) |f| internal.allocator.free(f);
+        window.drop_files.clearRetainingCapacity();
+        if (window.drop_text) |t| internal.allocator.free(t);
+        window.drop_text = null;
+        window.events.push(.drop_begin);
+    }
 }
 
 fn dataDeviceLeave(_: ?*anyopaque, _: ?*h.wl_data_device) callconv(.c) void {
@@ -1235,11 +1250,11 @@ fn dataDeviceDrop(_: ?*anyopaque, _: ?*h.wl_data_device) callconv(.c) void {
             const prefix = "file://";
             if (!std.mem.startsWith(u8, line, prefix)) continue;
             const path = uriDecodePath(line[prefix.len..]) orelse continue;
-            window.events.push(.{ .drop_file = path });
+            window.drop_files.append(internal.allocator, path) catch {};
         }
     } else {
         if (internal.allocator.dupe(u8, buf[0..total])) |copy| {
-            window.events.push(.{ .drop_text = copy });
+            window.drop_text = copy;
         } else |_| {}
     }
     window.events.push(.drop_complete);

--- a/src/unix/wayland.zig
+++ b/src/unix/wayland.zig
@@ -124,6 +124,13 @@ var touch_ids: std.StaticBitSet(256) = .initEmpty();
 var touch_info: std.AutoHashMapUnmanaged(i32, struct { public_id: u8, window: *Window }) = .empty;
 var clipboard_text: []const u8 = "";
 
+var pending_drag_has_uri: bool = false;
+var drag_offer: ?*h.wl_data_offer = null;
+var drag_has_uri: bool = false;
+var drag_serial: u32 = 0;
+var drag_window: ?*Window = null;
+var drag_dropped: bool = false;
+
 var egl_display: h.EGLDisplay = undefined;
 
 const exports = if (!build_options.system_integration) struct {
@@ -1146,15 +1153,126 @@ const data_device_listener = h.wl_data_device_listener{
     .selection = dataDeviceSelection,
 };
 
-fn dataDeviceDataOffer(_: ?*anyopaque, _: ?*h.wl_data_device, _: ?*h.wl_data_offer) callconv(.c) void {}
-fn dataDeviceEnter(_: ?*anyopaque, _: ?*h.wl_data_device, _: u32, _: ?*h.wl_surface, _: h.wl_fixed_t, _: h.wl_fixed_t, _: ?*h.wl_data_offer) callconv(.c) void {}
-fn dataDeviceLeave(_: ?*anyopaque, _: ?*h.wl_data_device) callconv(.c) void {}
+fn dataDeviceDataOffer(_: ?*anyopaque, _: ?*h.wl_data_device, offer: ?*h.wl_data_offer) callconv(.c) void {
+    pending_drag_has_uri = false;
+    if (offer) |_| _ = h.wl_data_offer_add_listener(offer, &data_offer_listener, null);
+}
+
+fn dataDeviceEnter(_: ?*anyopaque, _: ?*h.wl_data_device, serial: u32, surface: ?*h.wl_surface, _: h.wl_fixed_t, _: h.wl_fixed_t, offer: ?*h.wl_data_offer) callconv(.c) void {
+    drag_serial = serial;
+    drag_window = getWindow(surface);
+    drag_offer = offer;
+    drag_has_uri = pending_drag_has_uri;
+    drag_dropped = false;
+
+    if (offer) |o| {
+        if (drag_has_uri) {
+            h.wl_data_offer_accept(o, serial, "text/uri-list");
+        } else {
+            h.wl_data_offer_accept(o, serial, null);
+        }
+    }
+}
+
+fn dataDeviceLeave(_: ?*anyopaque, _: ?*h.wl_data_device) callconv(.c) void {
+    if (!drag_dropped) {
+        if (drag_window) |window| window.events.push(.drop_complete);
+    }
+    if (drag_offer) |o| {
+        h.wl_data_offer_destroy(o);
+        drag_offer = null;
+    }
+    drag_window = null;
+}
+
 fn dataDeviceMotion(_: ?*anyopaque, _: ?*h.wl_data_device, _: u32, _: h.wl_fixed_t, _: h.wl_fixed_t) callconv(.c) void {}
-fn dataDeviceDrop(_: ?*anyopaque, _: ?*h.wl_data_device) callconv(.c) void {}
+
+fn dataDeviceDrop(_: ?*anyopaque, _: ?*h.wl_data_device) callconv(.c) void {
+    const window = drag_window orelse return;
+    const offer = drag_offer orelse return;
+    if (!drag_has_uri) return;
+
+    var pipe: [2]i32 = undefined;
+    if (std.c.pipe(&pipe) == -1) {
+        window.events.push(.drop_complete);
+        return;
+    }
+    defer _ = std.c.close(pipe[0]);
+    h.wl_data_offer_receive(offer, "text/uri-list", pipe[1]);
+    _ = c.wl_display_roundtrip(display);
+    _ = std.c.close(pipe[1]);
+
+    var buf: [4096]u8 = undefined;
+    var total: usize = 0;
+    while (total < buf.len) {
+        const n = std.c.read(pipe[0], buf[total..].ptr, buf.len - total);
+        if (std.c.errno(n) != .SUCCESS or n == 0) break;
+        total += @intCast(n);
+    }
+
+    var iter = std.mem.splitAny(u8, buf[0..total], "\r\n");
+    while (iter.next()) |line| {
+        if (line.len == 0 or line[0] == '#') continue;
+        const prefix = "file://";
+        if (!std.mem.startsWith(u8, line, prefix)) continue;
+        const path = uriDecodePath(line[prefix.len..]) orelse continue;
+        window.events.push(.{ .drop_file = path });
+    }
+    window.events.push(.drop_complete);
+    drag_dropped = true;
+}
 
 fn dataDeviceSelection(_: ?*anyopaque, _: ?*h.wl_data_device, offer: ?*h.wl_data_offer) callconv(.c) void {
     if (data_offer) |_| h.wl_data_offer_destroy(data_offer);
     data_offer = offer;
+}
+
+const data_offer_listener = h.wl_data_offer_listener{
+    .offer = dataOfferMime,
+    .source_actions = dataOfferSourceActions,
+    .action = dataOfferAction,
+};
+
+fn dataOfferSourceActions(_: ?*anyopaque, _: ?*h.wl_data_offer, _: u32) callconv(.c) void {}
+fn dataOfferAction(_: ?*anyopaque, _: ?*h.wl_data_offer, _: u32) callconv(.c) void {}
+
+fn dataOfferMime(_: ?*anyopaque, _: ?*h.wl_data_offer, mime: [*c]const u8) callconv(.c) void {
+    if (std.mem.eql(u8, std.mem.sliceTo(mime, 0), "text/uri-list")) {
+        pending_drag_has_uri = true;
+    }
+}
+
+fn uriDecodePath(encoded: []const u8) ?[]u8 {
+    var path = internal.allocator.alloc(u8, encoded.len) catch return null;
+    var out: usize = 0;
+    var i: usize = 0;
+    while (i < encoded.len) {
+        if (encoded[i] == '%' and i + 2 < encoded.len) {
+            const hi = std.fmt.charToDigit(encoded[i + 1], 16) catch {
+                path[out] = encoded[i];
+                out += 1;
+                i += 1;
+                continue;
+            };
+            const lo = std.fmt.charToDigit(encoded[i + 2], 16) catch {
+                path[out] = encoded[i];
+                out += 1;
+                i += 1;
+                continue;
+            };
+            path[out] = (hi << 4) | lo;
+            out += 1;
+            i += 3;
+        } else {
+            path[out] = encoded[i];
+            out += 1;
+            i += 1;
+        }
+    }
+    return internal.allocator.realloc(path, out) catch {
+        internal.allocator.free(path);
+        return null;
+    };
 }
 
 const data_source_listener = h.wl_data_source_listener{

--- a/src/unix/wayland.zig
+++ b/src/unix/wayland.zig
@@ -440,8 +440,8 @@ pub const Window = struct {
         internal.allocator.destroy(self);
     }
 
-    pub fn getDropData(self: *Window) wio.DropData {
-        return .{ .files = self.drop_files.items, .text = self.drop_text };
+    pub fn getDropData(self: *Window, allocator: std.mem.Allocator) wio.DropData {
+        return wio.DropData.dupe(allocator, self.drop_files.items, self.drop_text) catch .{ .files = &.{}, .text = null };
     }
 
     pub fn getEvent(self: *Window) ?wio.Event {

--- a/src/unix/wayland.zig
+++ b/src/unix/wayland.zig
@@ -125,8 +125,10 @@ var touch_info: std.AutoHashMapUnmanaged(i32, struct { public_id: u8, window: *W
 var clipboard_text: []const u8 = "";
 
 var pending_drag_has_uri: bool = false;
+var pending_drag_has_text: bool = false;
 var drag_offer: ?*h.wl_data_offer = null;
 var drag_has_uri: bool = false;
+var drag_has_text: bool = false;
 var drag_serial: u32 = 0;
 var drag_window: ?*Window = null;
 var drag_dropped: bool = false;
@@ -1155,6 +1157,7 @@ const data_device_listener = h.wl_data_device_listener{
 
 fn dataDeviceDataOffer(_: ?*anyopaque, _: ?*h.wl_data_device, offer: ?*h.wl_data_offer) callconv(.c) void {
     pending_drag_has_uri = false;
+    pending_drag_has_text = false;
     if (offer) |_| _ = h.wl_data_offer_add_listener(offer, &data_offer_listener, null);
 }
 
@@ -1163,15 +1166,20 @@ fn dataDeviceEnter(_: ?*anyopaque, _: ?*h.wl_data_device, serial: u32, surface: 
     drag_window = getWindow(surface);
     drag_offer = offer;
     drag_has_uri = pending_drag_has_uri;
+    drag_has_text = pending_drag_has_text and !pending_drag_has_uri;
     drag_dropped = false;
 
     if (offer) |o| {
         if (drag_has_uri) {
             h.wl_data_offer_accept(o, serial, "text/uri-list");
+        } else if (drag_has_text) {
+            h.wl_data_offer_accept(o, serial, "text/plain;charset=utf-8");
         } else {
             h.wl_data_offer_accept(o, serial, null);
         }
     }
+
+    if (drag_window) |window| window.events.push(.drop_begin);
 }
 
 fn dataDeviceLeave(_: ?*anyopaque, _: ?*h.wl_data_device) callconv(.c) void {
@@ -1185,20 +1193,30 @@ fn dataDeviceLeave(_: ?*anyopaque, _: ?*h.wl_data_device) callconv(.c) void {
     drag_window = null;
 }
 
-fn dataDeviceMotion(_: ?*anyopaque, _: ?*h.wl_data_device, _: u32, _: h.wl_fixed_t, _: h.wl_fixed_t) callconv(.c) void {}
+fn dataDeviceMotion(_: ?*anyopaque, _: ?*h.wl_data_device, _: u32, x: h.wl_fixed_t, y: h.wl_fixed_t) callconv(.c) void {
+    if (drag_window) |window| {
+        const wx = std.math.cast(u16, x >> 8) orelse return;
+        const wy = std.math.cast(u16, y >> 8) orelse return;
+        window.events.push(.{ .drop_position = .{ .x = wx, .y = wy } });
+    }
+}
 
 fn dataDeviceDrop(_: ?*anyopaque, _: ?*h.wl_data_device) callconv(.c) void {
     const window = drag_window orelse return;
     const offer = drag_offer orelse return;
-    if (!drag_has_uri) return;
+    if (!drag_has_uri and !drag_has_text) return;
+
+    const mime = if (drag_has_uri) "text/uri-list" else "text/plain;charset=utf-8";
 
     var pipe: [2]i32 = undefined;
     if (std.c.pipe(&pipe) == -1) {
         window.events.push(.drop_complete);
+        drag_dropped = true;
         return;
     }
     defer _ = std.c.close(pipe[0]);
-    h.wl_data_offer_receive(offer, "text/uri-list", pipe[1]);
+    h.wl_data_offer_receive(offer, mime, pipe[1]);
+    drag_dropped = true; // set before roundtrip so dataDeviceLeave doesn't double-emit
     _ = c.wl_display_roundtrip(display);
     _ = std.c.close(pipe[1]);
 
@@ -1213,13 +1231,18 @@ fn dataDeviceDrop(_: ?*anyopaque, _: ?*h.wl_data_device) callconv(.c) void {
     var iter = std.mem.splitAny(u8, buf[0..total], "\r\n");
     while (iter.next()) |line| {
         if (line.len == 0 or line[0] == '#') continue;
-        const prefix = "file://";
-        if (!std.mem.startsWith(u8, line, prefix)) continue;
-        const path = uriDecodePath(line[prefix.len..]) orelse continue;
-        window.events.push(.{ .drop_file = path });
+        if (drag_has_uri) {
+            const prefix = "file://";
+            if (!std.mem.startsWith(u8, line, prefix)) continue;
+            const path = uriDecodePath(line[prefix.len..]) orelse continue;
+            window.events.push(.{ .drop_file = path });
+        } else {
+            if (internal.allocator.dupe(u8, line)) |copy| {
+                window.events.push(.{ .drop_text = copy });
+            } else |_| {}
+        }
     }
     window.events.push(.drop_complete);
-    drag_dropped = true;
 }
 
 fn dataDeviceSelection(_: ?*anyopaque, _: ?*h.wl_data_device, offer: ?*h.wl_data_offer) callconv(.c) void {
@@ -1237,8 +1260,11 @@ fn dataOfferSourceActions(_: ?*anyopaque, _: ?*h.wl_data_offer, _: u32) callconv
 fn dataOfferAction(_: ?*anyopaque, _: ?*h.wl_data_offer, _: u32) callconv(.c) void {}
 
 fn dataOfferMime(_: ?*anyopaque, _: ?*h.wl_data_offer, mime: [*c]const u8) callconv(.c) void {
-    if (std.mem.eql(u8, std.mem.sliceTo(mime, 0), "text/uri-list")) {
+    const s = std.mem.sliceTo(mime, 0);
+    if (std.mem.eql(u8, s, "text/uri-list")) {
         pending_drag_has_uri = true;
+    } else if (std.mem.eql(u8, s, "text/plain;charset=utf-8")) {
+        pending_drag_has_text = true;
     }
 }
 

--- a/src/unix/wayland.zig
+++ b/src/unix/wayland.zig
@@ -1251,8 +1251,8 @@ fn dataDeviceDrop(_: ?*anyopaque, _: ?*h.wl_data_device) callconv(.c) void {
             if (line.len == 0 or line[0] == '#') continue;
             const prefix = "file://";
             if (!std.mem.startsWith(u8, line, prefix)) continue;
-            const path = uriDecodePath(line[prefix.len..]) orelse continue;
-            window.drop_files.append(internal.allocator, path) catch {};
+            const path = internal.allocator.dupe(u8, line[prefix.len..]) catch continue;
+            window.drop_files.append(internal.allocator, std.Uri.percentDecodeInPlace(path)) catch {};
         }
     } else {
         if (internal.allocator.dupe(u8, buf[0..total])) |copy| {
@@ -1283,11 +1283,6 @@ fn dataOfferMime(_: ?*anyopaque, _: ?*h.wl_data_offer, mime: [*c]const u8) callc
     } else if (std.mem.eql(u8, s, "text/plain;charset=utf-8")) {
         pending_drag_has_text = true;
     }
-}
-
-fn uriDecodePath(encoded: []const u8) ?[]u8 {
-    const buf = internal.allocator.dupe(u8, encoded) catch return null;
-    return std.Uri.percentDecodeInPlace(buf);
 }
 
 const data_source_listener = h.wl_data_source_listener{

--- a/src/unix/wayland.zig
+++ b/src/unix/wayland.zig
@@ -1286,36 +1286,8 @@ fn dataOfferMime(_: ?*anyopaque, _: ?*h.wl_data_offer, mime: [*c]const u8) callc
 }
 
 fn uriDecodePath(encoded: []const u8) ?[]u8 {
-    var path = internal.allocator.alloc(u8, encoded.len) catch return null;
-    var out: usize = 0;
-    var i: usize = 0;
-    while (i < encoded.len) {
-        if (encoded[i] == '%' and i + 2 < encoded.len) {
-            const hi = std.fmt.charToDigit(encoded[i + 1], 16) catch {
-                path[out] = encoded[i];
-                out += 1;
-                i += 1;
-                continue;
-            };
-            const lo = std.fmt.charToDigit(encoded[i + 2], 16) catch {
-                path[out] = encoded[i];
-                out += 1;
-                i += 1;
-                continue;
-            };
-            path[out] = (hi << 4) | lo;
-            out += 1;
-            i += 3;
-        } else {
-            path[out] = encoded[i];
-            out += 1;
-            i += 1;
-        }
-    }
-    return internal.allocator.realloc(path, out) catch {
-        internal.allocator.free(path);
-        return null;
-    };
+    const buf = internal.allocator.dupe(u8, encoded) catch return null;
+    return std.Uri.percentDecodeInPlace(buf);
 }
 
 const data_source_listener = h.wl_data_source_listener{

--- a/src/unix/wayland.zig
+++ b/src/unix/wayland.zig
@@ -1228,19 +1228,19 @@ fn dataDeviceDrop(_: ?*anyopaque, _: ?*h.wl_data_device) callconv(.c) void {
         total += @intCast(n);
     }
 
-    var iter = std.mem.splitAny(u8, buf[0..total], "\r\n");
-    while (iter.next()) |line| {
-        if (line.len == 0 or line[0] == '#') continue;
-        if (drag_has_uri) {
+    if (drag_has_uri) {
+        var iter = std.mem.splitAny(u8, buf[0..total], "\r\n");
+        while (iter.next()) |line| {
+            if (line.len == 0 or line[0] == '#') continue;
             const prefix = "file://";
             if (!std.mem.startsWith(u8, line, prefix)) continue;
             const path = uriDecodePath(line[prefix.len..]) orelse continue;
             window.events.push(.{ .drop_file = path });
-        } else {
-            if (internal.allocator.dupe(u8, line)) |copy| {
-                window.events.push(.{ .drop_text = copy });
-            } else |_| {}
         }
+    } else {
+        if (internal.allocator.dupe(u8, buf[0..total])) |copy| {
+            window.events.push(.{ .drop_text = copy });
+        } else |_| {}
     }
     window.events.push(.drop_complete);
 }

--- a/src/unix/x11.zig
+++ b/src/unix/x11.zig
@@ -994,38 +994,8 @@ fn handle(event: *h.XEvent) void {
 fn uriToPath(uri: []const u8) ?[]u8 {
     const prefix = "file://";
     if (!std.mem.startsWith(u8, uri, prefix)) return null;
-    const encoded = uri[prefix.len..];
-
-    var path = internal.allocator.alloc(u8, encoded.len) catch return null;
-    var out: usize = 0;
-    var i: usize = 0;
-    while (i < encoded.len) {
-        if (encoded[i] == '%' and i + 2 < encoded.len) {
-            const hi = std.fmt.charToDigit(encoded[i + 1], 16) catch {
-                path[out] = encoded[i];
-                out += 1;
-                i += 1;
-                continue;
-            };
-            const lo = std.fmt.charToDigit(encoded[i + 2], 16) catch {
-                path[out] = encoded[i];
-                out += 1;
-                i += 1;
-                continue;
-            };
-            path[out] = hi << 4 | lo;
-            out += 1;
-            i += 3;
-        } else {
-            path[out] = encoded[i];
-            out += 1;
-            i += 1;
-        }
-    }
-    return internal.allocator.realloc(path, out) catch {
-        internal.allocator.free(path);
-        return null;
-    };
+    const buf = internal.allocator.dupe(u8, uri[prefix.len..]) catch return null;
+    return std.Uri.percentDecodeInPlace(buf);
 }
 
 fn handleKeyPress(window: *Window, event: *h.XEvent, repeat: bool) void {

--- a/src/unix/x11.zig
+++ b/src/unix/x11.zig
@@ -409,8 +409,8 @@ pub const Window = struct {
         return self.events.pop();
     }
 
-    pub fn getDropData(self: *Window) wio.DropData {
-        return .{ .files = self.drop_files.items, .text = self.drop_text };
+    pub fn getDropData(self: *Window, allocator: std.mem.Allocator) wio.DropData {
+        return wio.DropData.dupe(allocator, self.drop_files.items, self.drop_text) catch .{ .files = &.{}, .text = null };
     }
 
     pub fn enableTextInput(self: *Window, options: wio.TextInputOptions) void {

--- a/src/unix/x11.zig
+++ b/src/unix/x11.zig
@@ -101,6 +101,7 @@ var atoms: extern struct {
 } = undefined;
 
 var atom_text_uri_list: h.Atom = undefined;
+var atom_text_plain_utf8: h.Atom = undefined;
 
 var libX11: DynLib = undefined;
 var libXcursor: DynLib = undefined;
@@ -138,6 +139,7 @@ pub fn init() !bool {
     };
     _ = c.XInternAtoms(display, @ptrCast(&atom_names), atom_names.len, h.False, @ptrCast(&atoms));
     atom_text_uri_list = c.XInternAtom(display, "text/uri-list", h.False);
+    atom_text_plain_utf8 = c.XInternAtom(display, "text/plain;charset=utf-8", h.False);
 
     windows = .empty;
     errdefer windows.deinit(internal.allocator);
@@ -377,6 +379,7 @@ pub const Window = struct {
     xdnd_source: h.Window = 0,
     xdnd_req: h.Atom = h.None,
     xdnd_version: c_int = 0,
+    xdnd_is_text: bool = false,
     opengl: if (build_options.opengl) struct {
         colormap: h.Colormap,
         context: h.GLXContext,
@@ -747,6 +750,7 @@ fn handle(event: *h.XEvent) void {
                 window.xdnd_version = @intCast(event.xclient.data.l[1] >> 24);
                 const use_list = event.xclient.data.l[1] & 1 != 0;
                 window.xdnd_req = h.None;
+                window.xdnd_is_text = false;
                 if (use_list) {
                     var actual_type: h.Atom = undefined;
                     var actual_format: c_int = undefined;
@@ -758,17 +762,27 @@ fn handle(event: *h.XEvent) void {
                     for (@as([*]h.Atom, @ptrCast(@alignCast(data)))[0..nitems]) |atom| {
                         if (atom == atom_text_uri_list) {
                             window.xdnd_req = atom;
+                            window.xdnd_is_text = false;
                             break;
+                        } else if ((atom == atom_text_plain_utf8 or atom == atoms.UTF8_STRING) and window.xdnd_req == h.None) {
+                            window.xdnd_req = atom;
+                            window.xdnd_is_text = true;
                         }
                     }
                 } else {
                     for (1..4) |i| {
-                        if (@as(h.Atom, @bitCast(event.xclient.data.l[i])) == atom_text_uri_list) {
-                            window.xdnd_req = atom_text_uri_list;
+                        const atom: h.Atom = @bitCast(event.xclient.data.l[i]);
+                        if (atom == atom_text_uri_list) {
+                            window.xdnd_req = atom;
+                            window.xdnd_is_text = false;
                             break;
+                        } else if ((atom == atom_text_plain_utf8 or atom == atoms.UTF8_STRING) and window.xdnd_req == h.None) {
+                            window.xdnd_req = atom;
+                            window.xdnd_is_text = true;
                         }
                     }
                 }
+                window.events.push(.drop_begin);
             } else if (event.xclient.message_type == atoms.XdndPosition) {
                 const root_x: c_int = @intCast(event.xclient.data.l[2] >> 16);
                 const root_y: c_int = @intCast(event.xclient.data.l[2] & 0xffff);
@@ -776,6 +790,11 @@ fn handle(event: *h.XEvent) void {
                 var win_y: c_int = undefined;
                 var child: h.Window = undefined;
                 _ = c.XTranslateCoordinates(display, h.DefaultRootWindow(display), window.window, root_x, root_y, &win_x, &win_y, &child);
+                if (std.math.cast(u16, win_x)) |x| {
+                    if (std.math.cast(u16, win_y)) |y| {
+                        window.events.push(.{ .drop_position = .{ .x = x, .y = y } });
+                    }
+                }
 
                 var reply = h.XEvent{ .xclient = std.mem.zeroInit(h.XClientMessageEvent, .{
                     .type = h.ClientMessage,
@@ -790,6 +809,7 @@ fn handle(event: *h.XEvent) void {
                 _ = c.XSendEvent(display, window.xdnd_source, h.False, h.NoEventMask, &reply);
                 _ = c.XFlush(display);
             } else if (event.xclient.message_type == atoms.XdndLeave) {
+                window.events.push(.drop_complete);
                 window.xdnd_source = 0;
                 window.xdnd_req = h.None;
             } else if (event.xclient.message_type == atoms.XdndDrop) {
@@ -923,8 +943,14 @@ fn handle(event: *h.XEvent) void {
                     var iter = std.mem.splitAny(u8, data[0..nitems], "\r\n");
                     while (iter.next()) |line| {
                         if (line.len == 0 or line[0] == '#') continue;
-                        if (uriToPath(line)) |path| {
-                            window.events.push(.{ .drop_file = path });
+                        if (window.xdnd_is_text) {
+                            if (internal.allocator.dupe(u8, line)) |copy| {
+                                window.events.push(.{ .drop_text = copy });
+                            } else |_| {}
+                        } else {
+                            if (uriToPath(line)) |path| {
+                                window.events.push(.{ .drop_file = path });
+                            }
                         }
                     }
                 }

--- a/src/unix/x11.zig
+++ b/src/unix/x11.zig
@@ -52,7 +52,6 @@ var imports: extern struct {
     XSetClassHint: *const fn (?*h.Display, h.Window, [*c]h.XClassHint) callconv(.c) c_int,
     XSetSelectionOwner: *const fn (?*h.Display, h.Atom, h.Window, h.Time) callconv(.c) c_int,
     XConvertSelection: *const fn (?*h.Display, h.Atom, h.Atom, h.Atom, h.Window, h.Time) callconv(.c) c_int,
-    XInternAtom: *const fn (?*h.Display, [*c]const u8, c_int) callconv(.c) h.Atom,
     XTranslateCoordinates: *const fn (?*h.Display, h.Window, h.Window, c_int, c_int, [*c]c_int, [*c]c_int, [*c]h.Window) callconv(.c) c_int,
     XCheckTypedWindowEvent: *const fn (?*h.Display, h.Window, c_int, [*c]h.XEvent) callconv(.c) c_int,
     XCreateColormap: *const fn (?*h.Display, h.Window, [*c]h.Visual, c_int) callconv(.c) h.Colormap,
@@ -98,10 +97,9 @@ var atoms: extern struct {
     XdndTypeList: h.Atom,
     XdndSelection: h.Atom,
     XdndActionCopy: h.Atom,
+    @"text/uri-list": h.Atom,
+    @"text/plain;charset=utf-8": h.Atom,
 } = undefined;
-
-var atom_text_uri_list: h.Atom = undefined;
-var atom_text_plain_utf8: h.Atom = undefined;
 
 var libX11: DynLib = undefined;
 var libXcursor: DynLib = undefined;
@@ -138,8 +136,6 @@ pub fn init() !bool {
         break :blk atom_names;
     };
     _ = c.XInternAtoms(display, @ptrCast(&atom_names), atom_names.len, h.False, @ptrCast(&atoms));
-    atom_text_uri_list = c.XInternAtom(display, "text/uri-list", h.False);
-    atom_text_plain_utf8 = c.XInternAtom(display, "text/plain;charset=utf-8", h.False);
 
     windows = .empty;
     errdefer windows.deinit(internal.allocator);
@@ -380,6 +376,8 @@ pub const Window = struct {
     xdnd_req: h.Atom = h.None,
     xdnd_version: c_int = 0,
     xdnd_is_text: bool = false,
+    drop_files: std.ArrayListUnmanaged([]const u8) = .empty,
+    drop_text: ?[]const u8 = null,
     opengl: if (build_options.opengl) struct {
         colormap: h.Colormap,
         context: h.GLXContext,
@@ -398,11 +396,18 @@ pub const Window = struct {
 
         self.preedit_string.deinit(internal.allocator);
         self.events.deinit();
+        for (self.drop_files.items) |f| internal.allocator.free(f);
+        self.drop_files.deinit(internal.allocator);
+        if (self.drop_text) |t| internal.allocator.free(t);
         internal.allocator.destroy(self);
     }
 
     pub fn getEvent(self: *Window) ?wio.Event {
         return self.events.pop();
+    }
+
+    pub fn getDropData(self: *Window) wio.DropData {
+        return .{ .files = self.drop_files.items, .text = self.drop_text };
     }
 
     pub fn enableTextInput(self: *Window, options: wio.TextInputOptions) void {
@@ -760,11 +765,11 @@ fn handle(event: *h.XEvent) void {
                     _ = c.XGetWindowProperty(display, window.xdnd_source, atoms.XdndTypeList, 0, std.math.maxInt(c_long), h.False, h.XA_ATOM, &actual_type, &actual_format, &nitems, &bytes_after, @ptrCast(&data));
                     defer _ = c.XFree(data);
                     for (@as([*]h.Atom, @ptrCast(@alignCast(data)))[0..nitems]) |atom| {
-                        if (atom == atom_text_uri_list) {
+                        if (atom == atoms.@"text/uri-list") {
                             window.xdnd_req = atom;
                             window.xdnd_is_text = false;
                             break;
-                        } else if ((atom == atom_text_plain_utf8 or atom == atoms.UTF8_STRING) and window.xdnd_req == h.None) {
+                        } else if ((atom == atoms.@"text/plain;charset=utf-8" or atom == atoms.UTF8_STRING) and window.xdnd_req == h.None) {
                             window.xdnd_req = atom;
                             window.xdnd_is_text = true;
                         }
@@ -772,16 +777,20 @@ fn handle(event: *h.XEvent) void {
                 } else {
                     for (1..4) |i| {
                         const atom: h.Atom = @bitCast(event.xclient.data.l[i]);
-                        if (atom == atom_text_uri_list) {
+                        if (atom == atoms.@"text/uri-list") {
                             window.xdnd_req = atom;
                             window.xdnd_is_text = false;
                             break;
-                        } else if ((atom == atom_text_plain_utf8 or atom == atoms.UTF8_STRING) and window.xdnd_req == h.None) {
+                        } else if ((atom == atoms.@"text/plain;charset=utf-8" or atom == atoms.UTF8_STRING) and window.xdnd_req == h.None) {
                             window.xdnd_req = atom;
                             window.xdnd_is_text = true;
                         }
                     }
                 }
+                for (window.drop_files.items) |f| internal.allocator.free(f);
+                window.drop_files.clearRetainingCapacity();
+                if (window.drop_text) |t| internal.allocator.free(t);
+                window.drop_text = null;
                 window.events.push(.drop_begin);
             } else if (event.xclient.message_type == atoms.XdndPosition) {
                 const root_x: c_int = @intCast(event.xclient.data.l[2] >> 16);
@@ -942,14 +951,14 @@ fn handle(event: *h.XEvent) void {
                 if (actual_format == 8) {
                     if (window.xdnd_is_text) {
                         if (internal.allocator.dupe(u8, data[0..nitems])) |copy| {
-                            window.events.push(.{ .drop_text = copy });
+                            window.drop_text = copy;
                         } else |_| {}
                     } else {
                         var iter = std.mem.splitAny(u8, data[0..nitems], "\r\n");
                         while (iter.next()) |line| {
                             if (line.len == 0 or line[0] == '#') continue;
                             if (uriToPath(line)) |path| {
-                                window.events.push(.{ .drop_file = path });
+                                window.drop_files.append(internal.allocator, path) catch {};
                             }
                         }
                     }

--- a/src/unix/x11.zig
+++ b/src/unix/x11.zig
@@ -960,9 +960,10 @@ fn handle(event: *h.XEvent) void {
                         var iter = std.mem.splitAny(u8, data[0..nitems], "\r\n");
                         while (iter.next()) |line| {
                             if (line.len == 0 or line[0] == '#') continue;
-                            if (uriToPath(line)) |path| {
-                                window.drop_files.append(internal.allocator, path) catch {};
-                            }
+                            const prefix = "file://";
+                            if (!std.mem.startsWith(u8, line, prefix)) continue;
+                            const path = internal.allocator.dupe(u8, line[prefix.len..]) catch continue;
+                            window.drop_files.append(internal.allocator, std.Uri.percentDecodeInPlace(path)) catch {};
                         }
                     }
                 }
@@ -989,13 +990,6 @@ fn handle(event: *h.XEvent) void {
         },
         else => {},
     }
-}
-
-fn uriToPath(uri: []const u8) ?[]u8 {
-    const prefix = "file://";
-    if (!std.mem.startsWith(u8, uri, prefix)) return null;
-    const buf = internal.allocator.dupe(u8, uri[prefix.len..]) catch return null;
-    return std.Uri.percentDecodeInPlace(buf);
 }
 
 fn handleKeyPress(window: *Window, event: *h.XEvent, repeat: bool) void {

--- a/src/unix/x11.zig
+++ b/src/unix/x11.zig
@@ -940,14 +940,14 @@ fn handle(event: *h.XEvent) void {
                 defer _ = c.XFree(data);
 
                 if (actual_format == 8) {
-                    var iter = std.mem.splitAny(u8, data[0..nitems], "\r\n");
-                    while (iter.next()) |line| {
-                        if (line.len == 0 or line[0] == '#') continue;
-                        if (window.xdnd_is_text) {
-                            if (internal.allocator.dupe(u8, line)) |copy| {
-                                window.events.push(.{ .drop_text = copy });
-                            } else |_| {}
-                        } else {
+                    if (window.xdnd_is_text) {
+                        if (internal.allocator.dupe(u8, data[0..nitems])) |copy| {
+                            window.events.push(.{ .drop_text = copy });
+                        } else |_| {}
+                    } else {
+                        var iter = std.mem.splitAny(u8, data[0..nitems], "\r\n");
+                        while (iter.next()) |line| {
+                            if (line.len == 0 or line[0] == '#') continue;
                             if (uriToPath(line)) |path| {
                                 window.events.push(.{ .drop_file = path });
                             }

--- a/src/unix/x11.zig
+++ b/src/unix/x11.zig
@@ -52,6 +52,8 @@ var imports: extern struct {
     XSetClassHint: *const fn (?*h.Display, h.Window, [*c]h.XClassHint) callconv(.c) c_int,
     XSetSelectionOwner: *const fn (?*h.Display, h.Atom, h.Window, h.Time) callconv(.c) c_int,
     XConvertSelection: *const fn (?*h.Display, h.Atom, h.Atom, h.Atom, h.Window, h.Time) callconv(.c) c_int,
+    XInternAtom: *const fn (?*h.Display, [*c]const u8, c_int) callconv(.c) h.Atom,
+    XTranslateCoordinates: *const fn (?*h.Display, h.Window, h.Window, c_int, c_int, [*c]c_int, [*c]c_int, [*c]h.Window) callconv(.c) c_int,
     XCheckTypedWindowEvent: *const fn (?*h.Display, h.Window, c_int, [*c]h.XEvent) callconv(.c) c_int,
     XCreateColormap: *const fn (?*h.Display, h.Window, [*c]h.Visual, c_int) callconv(.c) h.Colormap,
     XFreeColormap: *const fn (?*h.Display, h.Colormap) callconv(.c) c_int,
@@ -86,7 +88,19 @@ var atoms: extern struct {
     TARGETS: h.Atom,
     INCR: h.Atom,
     SELECTION: h.Atom,
+    XdndAware: h.Atom,
+    XdndEnter: h.Atom,
+    XdndPosition: h.Atom,
+    XdndStatus: h.Atom,
+    XdndLeave: h.Atom,
+    XdndDrop: h.Atom,
+    XdndFinished: h.Atom,
+    XdndTypeList: h.Atom,
+    XdndSelection: h.Atom,
+    XdndActionCopy: h.Atom,
 } = undefined;
+
+var atom_text_uri_list: h.Atom = undefined;
 
 var libX11: DynLib = undefined;
 var libXcursor: DynLib = undefined;
@@ -123,6 +137,7 @@ pub fn init() !bool {
         break :blk atom_names;
     };
     _ = c.XInternAtoms(display, @ptrCast(&atom_names), atom_names.len, h.False, @ptrCast(&atoms));
+    atom_text_uri_list = c.XInternAtom(display, "text/uri-list", h.False);
 
     windows = .empty;
     errdefer windows.deinit(internal.allocator);
@@ -291,6 +306,9 @@ pub fn createWindow(options: wio.CreateWindowOptions) !*Window {
     const protocols = [_]h.Atom{atoms.WM_DELETE_WINDOW};
     _ = c.XChangeProperty(display, window, atoms.WM_PROTOCOLS, h.XA_ATOM, 32, h.PropModeReplace, @ptrCast(&protocols), protocols.len);
 
+    const xdnd_version: c_long = 5;
+    _ = c.XChangeProperty(display, window, atoms.XdndAware, h.XA_ATOM, 32, h.PropModeReplace, @ptrCast(&xdnd_version), 1);
+
     const self = try internal.allocator.create(Window);
     errdefer internal.allocator.destroy(self);
 
@@ -356,6 +374,9 @@ pub const Window = struct {
     cursor_mode: wio.CursorMode = .normal,
     size: wio.Size,
     warped: bool = false,
+    xdnd_source: h.Window = 0,
+    xdnd_req: h.Atom = h.None,
+    xdnd_version: c_int = 0,
     opengl: if (build_options.opengl) struct {
         colormap: h.Colormap,
         context: h.GLXContext,
@@ -721,6 +742,71 @@ fn handle(event: *h.XEvent) void {
                 if (event.xclient.data.l[0] == atoms.WM_DELETE_WINDOW) {
                     window.events.push(.close);
                 }
+            } else if (event.xclient.message_type == atoms.XdndEnter) {
+                window.xdnd_source = @intCast(event.xclient.data.l[0]);
+                window.xdnd_version = @intCast(event.xclient.data.l[1] >> 24);
+                const use_list = event.xclient.data.l[1] & 1 != 0;
+                window.xdnd_req = h.None;
+                if (use_list) {
+                    var actual_type: h.Atom = undefined;
+                    var actual_format: c_int = undefined;
+                    var nitems: c_ulong = undefined;
+                    var bytes_after: c_ulong = undefined;
+                    var data: [*]u8 = undefined;
+                    _ = c.XGetWindowProperty(display, window.xdnd_source, atoms.XdndTypeList, 0, std.math.maxInt(c_long), h.False, h.XA_ATOM, &actual_type, &actual_format, &nitems, &bytes_after, @ptrCast(&data));
+                    defer _ = c.XFree(data);
+                    for (@as([*]h.Atom, @ptrCast(@alignCast(data)))[0..nitems]) |atom| {
+                        if (atom == atom_text_uri_list) {
+                            window.xdnd_req = atom;
+                            break;
+                        }
+                    }
+                } else {
+                    for (1..4) |i| {
+                        if (@as(h.Atom, @bitCast(event.xclient.data.l[i])) == atom_text_uri_list) {
+                            window.xdnd_req = atom_text_uri_list;
+                            break;
+                        }
+                    }
+                }
+            } else if (event.xclient.message_type == atoms.XdndPosition) {
+                const root_x: c_int = @intCast(event.xclient.data.l[2] >> 16);
+                const root_y: c_int = @intCast(event.xclient.data.l[2] & 0xffff);
+                var win_x: c_int = undefined;
+                var win_y: c_int = undefined;
+                var child: h.Window = undefined;
+                _ = c.XTranslateCoordinates(display, h.DefaultRootWindow(display), window.window, root_x, root_y, &win_x, &win_y, &child);
+
+                var reply = h.XEvent{ .xclient = std.mem.zeroInit(h.XClientMessageEvent, .{
+                    .type = h.ClientMessage,
+                    .display = display,
+                    .window = window.xdnd_source,
+                    .message_type = atoms.XdndStatus,
+                    .format = 32,
+                }) };
+                reply.xclient.data.l[0] = @bitCast(@as(c_ulong, window.window));
+                reply.xclient.data.l[1] = if (window.xdnd_req != h.None) 1 else 0;
+                reply.xclient.data.l[4] = @bitCast(atoms.XdndActionCopy);
+                _ = c.XSendEvent(display, window.xdnd_source, h.False, h.NoEventMask, &reply);
+                _ = c.XFlush(display);
+            } else if (event.xclient.message_type == atoms.XdndLeave) {
+                window.xdnd_source = 0;
+                window.xdnd_req = h.None;
+            } else if (event.xclient.message_type == atoms.XdndDrop) {
+                if (window.xdnd_req == h.None) {
+                    var reply = h.XEvent{ .xclient = std.mem.zeroInit(h.XClientMessageEvent, .{
+                        .type = h.ClientMessage,
+                        .display = display,
+                        .window = window.xdnd_source,
+                        .message_type = atoms.XdndFinished,
+                        .format = 32,
+                    }) };
+                    reply.xclient.data.l[0] = @bitCast(@as(c_ulong, window.window));
+                    _ = c.XSendEvent(display, window.xdnd_source, h.False, h.NoEventMask, &reply);
+                } else {
+                    const time: h.Time = if (window.xdnd_version >= 1) @intCast(event.xclient.data.l[2]) else h.CurrentTime;
+                    _ = c.XConvertSelection(display, atoms.XdndSelection, window.xdnd_req, atoms.SELECTION, window.window, time);
+                }
             }
         },
         h.FocusIn => {
@@ -823,8 +909,85 @@ fn handle(event: *h.XEvent) void {
         h.LeaveNotify => {
             window.events.push(.mouse_leave);
         },
+        h.SelectionNotify => {
+            if (window.xdnd_req != h.None and event.xselection.property != h.None and event.xselection.selection == atoms.XdndSelection) {
+                var actual_type: h.Atom = undefined;
+                var actual_format: c_int = undefined;
+                var nitems: c_ulong = undefined;
+                var bytes_after: c_ulong = undefined;
+                var data: [*]u8 = undefined;
+                _ = c.XGetWindowProperty(display, window.window, atoms.SELECTION, 0, std.math.maxInt(c_long), h.True, h.AnyPropertyType, &actual_type, &actual_format, &nitems, &bytes_after, @ptrCast(&data));
+                defer _ = c.XFree(data);
+
+                if (actual_format == 8) {
+                    var iter = std.mem.splitAny(u8, data[0..nitems], "\r\n");
+                    while (iter.next()) |line| {
+                        if (line.len == 0 or line[0] == '#') continue;
+                        if (uriToPath(line)) |path| {
+                            window.events.push(.{ .drop_file = path });
+                        }
+                    }
+                }
+                window.events.push(.drop_complete);
+
+                var reply = h.XEvent{ .xclient = std.mem.zeroInit(h.XClientMessageEvent, .{
+                    .type = h.ClientMessage,
+                    .display = display,
+                    .window = window.xdnd_source,
+                    .message_type = atoms.XdndFinished,
+                    .format = 32,
+                }) };
+                reply.xclient.data.l[0] = @bitCast(@as(c_ulong, window.window));
+                reply.xclient.data.l[1] = 1;
+                reply.xclient.data.l[2] = @bitCast(atoms.XdndActionCopy);
+                _ = c.XSendEvent(display, window.xdnd_source, h.False, h.NoEventMask, &reply);
+                _ = c.XFlush(display);
+
+                window.xdnd_source = 0;
+                window.xdnd_req = h.None;
+            } else {
+                // clipboard SelectionNotify is handled in getClipboardText via XCheckTypedWindowEvent
+            }
+        },
         else => {},
     }
+}
+
+fn uriToPath(uri: []const u8) ?[]u8 {
+    const prefix = "file://";
+    if (!std.mem.startsWith(u8, uri, prefix)) return null;
+    const encoded = uri[prefix.len..];
+
+    var path = internal.allocator.alloc(u8, encoded.len) catch return null;
+    var out: usize = 0;
+    var i: usize = 0;
+    while (i < encoded.len) {
+        if (encoded[i] == '%' and i + 2 < encoded.len) {
+            const hi = std.fmt.charToDigit(encoded[i + 1], 16) catch {
+                path[out] = encoded[i];
+                out += 1;
+                i += 1;
+                continue;
+            };
+            const lo = std.fmt.charToDigit(encoded[i + 2], 16) catch {
+                path[out] = encoded[i];
+                out += 1;
+                i += 1;
+                continue;
+            };
+            path[out] = hi << 4 | lo;
+            out += 1;
+            i += 3;
+        } else {
+            path[out] = encoded[i];
+            out += 1;
+            i += 1;
+        }
+    }
+    return internal.allocator.realloc(path, out) catch {
+        internal.allocator.free(path);
+        return null;
+    };
 }
 
 fn handleKeyPress(window: *Window, event: *h.XEvent, repeat: bool) void {

--- a/src/wasm.zig
+++ b/src/wasm.zig
@@ -97,14 +97,8 @@ pub fn createWindow(options: wio.CreateWindowOptions) !Window {
 
 pub const Window = struct {
     id: u32,
-    drop_files: std.ArrayListUnmanaged([]const u8) = .empty,
-    drop_text: ?[]const u8 = null,
 
-    pub fn destroy(self: *Window) void {
-        for (self.drop_files.items) |f| internal.allocator.free(f);
-        self.drop_files.deinit(internal.allocator);
-        if (self.drop_text) |t| internal.allocator.free(t);
-    }
+    pub fn destroy(_: *Window) void {}
 
     pub fn getEvent(self: *Window) ?wio.Event {
         const event: wio.EventType = @enumFromInt(js.shift(self.id));
@@ -175,30 +169,32 @@ pub const Window = struct {
         return null;
     }
 
-    pub fn getDropData(self: *Window) wio.DropData {
-        for (self.drop_files.items) |f| internal.allocator.free(f);
-        self.drop_files.clearRetainingCapacity();
-        if (self.drop_text) |t| internal.allocator.free(t);
-        self.drop_text = null;
+    pub fn getDropData(self: *Window, allocator: std.mem.Allocator) wio.DropData {
+        return getDropDataInner(self, allocator) catch .{ .files = &.{}, .text = null };
+    }
 
+    fn getDropDataInner(self: *Window, allocator: std.mem.Allocator) !wio.DropData {
         const file_count = js.getDropFileCount(self.id);
+        const files = try allocator.alloc([]const u8, file_count);
+        var n: usize = 0;
+        errdefer {
+            for (files[0..n]) |f| allocator.free(f);
+            allocator.free(files);
+        }
         for (0..file_count) |i| {
             const len = js.getDropFileLen(self.id, @intCast(i));
-            const buf = internal.allocator.alloc(u8, len) catch continue;
+            const buf = try allocator.alloc(u8, len);
             js.getDropFile(self.id, @intCast(i), buf.ptr);
-            self.drop_files.append(internal.allocator, buf) catch {
-                internal.allocator.free(buf);
-            };
+            files[n] = buf;
+            n += 1;
         }
         const text_len = js.getDropTextLen(self.id);
-        if (text_len > 0) {
-            if (internal.allocator.alloc(u8, text_len)) |buf| {
-                js.getDropText(self.id, buf.ptr);
-                self.drop_text = buf;
-            } else |_| {}
-        }
-
-        return .{ .files = self.drop_files.items, .text = self.drop_text };
+        const text: ?[]u8 = if (text_len > 0) blk: {
+            const buf = try allocator.alloc(u8, text_len);
+            js.getDropText(self.id, buf.ptr);
+            break :blk buf;
+        } else null;
+        return .{ .files = files, .text = text };
     }
 
     pub fn createFramebuffer(_: *Window, size: wio.Size) !Framebuffer {

--- a/src/wasm.zig
+++ b/src/wasm.zig
@@ -36,6 +36,11 @@ const js = struct {
     extern "wio" fn setSize(u32, u16, u16) void;
     extern "wio" fn setClipboardText([*]const u8, usize) void;
     extern "wio" fn presentFramebuffer(u32, [*]const u32, u16, u16) void;
+    extern "wio" fn getDropFileCount(u32) u32;
+    extern "wio" fn getDropFileLen(u32, u32) u32;
+    extern "wio" fn getDropFile(u32, u32, [*]u8) void;
+    extern "wio" fn getDropTextLen(u32) u32;
+    extern "wio" fn getDropText(u32, [*]u8) void;
     extern "wio" fn getJoystickCount() u32;
     extern "wio" fn getJoystickIdLen(u32) u32;
     extern "wio" fn getJoystickId(u32, [*]u8) void;
@@ -92,8 +97,14 @@ pub fn createWindow(options: wio.CreateWindowOptions) !Window {
 
 pub const Window = struct {
     id: u32,
+    drop_files: std.ArrayListUnmanaged([]const u8) = .empty,
+    drop_text: ?[]const u8 = null,
 
-    pub fn destroy(_: *Window) void {}
+    pub fn destroy(self: *Window) void {
+        for (self.drop_files.items) |f| internal.allocator.free(f);
+        self.drop_files.deinit(internal.allocator);
+        if (self.drop_text) |t| internal.allocator.free(t);
+    }
 
     pub fn getEvent(self: *Window) ?wio.Event {
         const event: wio.EventType = @enumFromInt(js.shift(self.id));
@@ -118,6 +129,9 @@ pub const Window = struct {
             .mouse_leave => .mouse_leave,
             .scroll_vertical => .{ .scroll_vertical = js.shiftFloat(self.id) },
             .scroll_horizontal => .{ .scroll_horizontal = js.shiftFloat(self.id) },
+            .drop_begin => .drop_begin,
+            .drop_position => .{ .drop_position = .{ .x = @intCast(js.shift(self.id)), .y = @intCast(js.shift(self.id)) } },
+            .drop_complete => .drop_complete,
             else => unreachable,
         };
     }
@@ -159,6 +173,32 @@ pub const Window = struct {
 
     pub fn getClipboardText(_: *Window, _: std.mem.Allocator) ?[]u8 {
         return null;
+    }
+
+    pub fn getDropData(self: *Window) wio.DropData {
+        for (self.drop_files.items) |f| internal.allocator.free(f);
+        self.drop_files.clearRetainingCapacity();
+        if (self.drop_text) |t| internal.allocator.free(t);
+        self.drop_text = null;
+
+        const file_count = js.getDropFileCount(self.id);
+        for (0..file_count) |i| {
+            const len = js.getDropFileLen(self.id, @intCast(i));
+            const buf = internal.allocator.alloc(u8, len) catch continue;
+            js.getDropFile(self.id, @intCast(i), buf.ptr);
+            self.drop_files.append(internal.allocator, buf) catch {
+                internal.allocator.free(buf);
+            };
+        }
+        const text_len = js.getDropTextLen(self.id);
+        if (text_len > 0) {
+            if (internal.allocator.alloc(u8, text_len)) |buf| {
+                js.getDropText(self.id, buf.ptr);
+                self.drop_text = buf;
+            } else |_| {}
+        }
+
+        return .{ .files = self.drop_files.items, .text = self.drop_text };
     }
 
     pub fn createFramebuffer(_: *Window, size: wio.Size) !Framebuffer {

--- a/src/wasm/Wio.js
+++ b/src/wasm/Wio.js
@@ -115,6 +115,8 @@ class Wio {
                 text: false,
                 cursor: "default",
                 cursor_mode: 0,
+                drop_files: [],
+                drop_text: null,
             };
 
             new ResizeObserver(() => {
@@ -178,6 +180,25 @@ class Wio {
             canvas.addEventListener("wheel", (event) => {
                 if (event.deltaY !== 0) events.push(20, event.deltaY);
                 if (event.deltaX !== 0) events.push(21, event.deltaX);
+            });
+            canvas.addEventListener("dragenter", (event) => {
+                event.preventDefault();
+                window.drop_files = [];
+                window.drop_text = null;
+                events.push(24);
+            });
+            canvas.addEventListener("dragover", (event) => {
+                event.preventDefault();
+                events.push(25, event.offsetX, event.offsetY);
+            });
+            canvas.addEventListener("drop", (event) => {
+                event.preventDefault();
+                for (const file of event.dataTransfer.files) {
+                    window.drop_files.push(file.name);
+                }
+                const text = event.dataTransfer.getData("text/plain");
+                window.drop_text = text.length > 0 ? text : null;
+                events.push(26);
             });
 
             this.windows.push(window);
@@ -261,6 +282,23 @@ class Wio {
             const framebuffer = new Uint8ClampedArray(this.instance.exports.memory.buffer, ptr, width * height * 4);
             const image = new ImageData(framebuffer, width, height);
             this.windows[id].canvas.getContext("2d").putImageData(image, 0, 0);
+        },
+
+        getDropFileCount: (id) => this.windows[id].drop_files.length,
+
+        getDropFileLen: (id, index) => new TextEncoder().encode(this.windows[id].drop_files[index]).length,
+
+        getDropFile: (id, index, ptr) => {
+            new TextEncoder().encodeInto(this.windows[id].drop_files[index], new Uint8Array(this.instance.exports.memory.buffer, ptr));
+        },
+
+        getDropTextLen: (id) => {
+            const text = this.windows[id].drop_text;
+            return text !== null ? new TextEncoder().encode(text).length : 0;
+        },
+
+        getDropText: (id, ptr) => {
+            new TextEncoder().encodeInto(this.windows[id].drop_text, new Uint8Array(this.instance.exports.memory.buffer, ptr));
         },
 
         getJoystickCount: () => this.gamepads.length,

--- a/src/win32.zig
+++ b/src/win32.zig
@@ -114,8 +114,9 @@ pub fn init() !void {
         if (w.RegisterRawInputDevices(&devices, devices.len, @sizeOf(w.RAWINPUTDEVICE)) == w.FALSE) return logLastError("RegisterRawInputDevices");
     }
 
+    try SUCCEED(w.OleInitialize(null), "OleInitialize");
+
     if (build_options.audio) {
-        try SUCCEED(w.CoInitializeEx(null, w.COINIT_MULTITHREADED | w.COINIT_DISABLE_OLE1DDE), "CoInitializeEx");
         try SUCCEED(w.CoCreateInstance(&w.CLSID_MMDeviceEnumerator, null, w.CLSCTX_ALL, &w.IID_IMMDeviceEnumerator, @ptrCast(&mm_device_enumerator)), "CoCreateInstance");
 
         var device: *w.IMMDevice = undefined;
@@ -151,10 +152,10 @@ pub fn deinit() void {
 
     if (build_options.audio) {
         _ = mm_device_enumerator.Release();
-        w.CoUninitialize();
     }
 
     _ = w.DestroyWindow(helper_window);
+    w.OleUninitialize();
 }
 
 pub fn run(func: fn () anyerror!bool) !void {
@@ -338,6 +339,9 @@ pub fn createWindow(options: wio.CreateWindowOptions) !*Window {
         }
     }
 
+    self.drop_target = .{ .window = self };
+    _ = w.RegisterDragDrop(window, &self.drop_target.interface);
+
     return self;
 }
 
@@ -365,8 +369,10 @@ pub const Window = struct {
     touch_ids: std.AutoHashMapUnmanaged(u16, u8) = .empty,
     text: bool = false,
     opengl: if (build_options.opengl) struct { dc: w.HDC = null, rc: w.HGLRC = null } else struct {} = .{},
+    drop_target: DropTarget = undefined,
 
     pub fn destroy(self: *Window) void {
+        _ = w.RevokeDragDrop(self.window);
         if (build_options.opengl) {
             _ = w.wglDeleteContext(self.opengl.rc);
             _ = w.ReleaseDC(self.window, self.opengl.dc);
@@ -1183,6 +1189,142 @@ fn enableRawMouse() void {
         }
     }
 }
+
+const DropTarget = struct {
+    interface: w.IDropTarget = .{ .lpVtbl = &vtable },
+    window: *Window = undefined,
+    has_files: bool = false,
+    has_text: bool = false,
+
+    const vtable: w.IDropTarget.Vtbl = .{
+        .QueryInterface = queryInterface,
+        .AddRef = addRef,
+        .Release = release,
+        .DragEnter = dragEnter,
+        .DragOver = dragOver,
+        .DragLeave = dragLeave,
+        .Drop = drop,
+    };
+
+    fn cast(iface: *w.IDropTarget) *DropTarget {
+        return @fieldParentPtr("interface", iface);
+    }
+
+    fn queryInterface(iface: *w.IDropTarget, riid: [*c]const w.GUID, obj: [*c]?*anyopaque) callconv(.winapi) w.HRESULT {
+        const guid: *const w.GUID = @ptrCast(riid);
+        if (std.mem.eql(u8, std.mem.asBytes(guid), std.mem.asBytes(&w.IID_IDropTarget)) or
+            std.mem.eql(u8, std.mem.asBytes(guid), std.mem.asBytes(&w.IID_IUnknown)))
+        {
+            obj.* = iface;
+            return w.S_OK;
+        }
+        obj.* = null;
+        return w.E_NOINTERFACE;
+    }
+
+    fn addRef(_: *w.IDropTarget) callconv(.winapi) u32 {
+        return 1;
+    }
+
+    fn release(_: *w.IDropTarget) callconv(.winapi) u32 {
+        return 1;
+    }
+
+    fn makeFormatEtc(cf: u16) w.FORMATETC {
+        return .{
+            .cfFormat = cf,
+            .ptd = null,
+            .dwAspect = w.DVASPECT_CONTENT,
+            .lindex = -1,
+            .tymed = @intCast(w.TYMED_HGLOBAL),
+        };
+    }
+
+    fn pushPosition(window: *Window, pt: w.POINTL) void {
+        var point = w.POINT{ .x = pt.x, .y = pt.y };
+        _ = w.ScreenToClient(window.window, &point);
+        const x = std.math.cast(u16, point.x) orelse return;
+        const y = std.math.cast(u16, point.y) orelse return;
+        window.events.push(.{ .drop_position = .{ .x = x, .y = y } });
+    }
+
+    fn dragEnter(iface: *w.IDropTarget, data: [*c]w.IDataObject, _: u32, pt: w.POINTL, effect: [*c]u32) callconv(.winapi) w.HRESULT {
+        const dt = cast(iface);
+        const data_obj: *w.IDataObject = @ptrCast(data);
+        var fmt = makeFormatEtc(w.CF_HDROP);
+        dt.has_files = data_obj.QueryGetData(&fmt) == w.S_OK;
+        fmt.cfFormat = w.CF_UNICODETEXT;
+        dt.has_text = data_obj.QueryGetData(&fmt) == w.S_OK;
+        if (dt.has_files or dt.has_text) {
+            effect.* = w.DROPEFFECT_COPY;
+            dt.window.events.push(.drop_begin);
+            pushPosition(dt.window, pt);
+        } else {
+            effect.* = w.DROPEFFECT_NONE;
+        }
+        return w.S_OK;
+    }
+
+    fn dragOver(iface: *w.IDropTarget, _: u32, pt: w.POINTL, effect: [*c]u32) callconv(.winapi) w.HRESULT {
+        const dt = cast(iface);
+        if (dt.has_files or dt.has_text) {
+            effect.* = w.DROPEFFECT_COPY;
+            pushPosition(dt.window, pt);
+        } else {
+            effect.* = w.DROPEFFECT_NONE;
+        }
+        return w.S_OK;
+    }
+
+    fn dragLeave(_: *w.IDropTarget) callconv(.winapi) w.HRESULT {
+        return w.S_OK;
+    }
+
+    fn drop(iface: *w.IDropTarget, data: [*c]w.IDataObject, _: u32, pt: w.POINTL, effect: [*c]u32) callconv(.winapi) w.HRESULT {
+        const dt = cast(iface);
+        const data_obj: *w.IDataObject = @ptrCast(data);
+        if (!dt.has_files and !dt.has_text) {
+            effect.* = w.DROPEFFECT_NONE;
+            return w.S_OK;
+        }
+        effect.* = w.DROPEFFECT_COPY;
+        pushPosition(dt.window, pt);
+        if (dt.has_files) extractFiles(dt.window, data_obj);
+        if (dt.has_text) extractText(dt.window, data_obj);
+        dt.window.events.push(.drop_complete);
+        return w.S_OK;
+    }
+
+    fn extractFiles(window: *Window, data: *w.IDataObject) void {
+        var fmt = makeFormatEtc(w.CF_HDROP);
+        var medium: w.STGMEDIUM = undefined;
+        if (data.GetData(&fmt, &medium) != w.S_OK) return;
+        defer w.ReleaseStgMedium(&medium);
+        const hdrop: w.HDROP = medium.u.hGlobal;
+        const count = w.DragQueryFileW(hdrop, 0xFFFFFFFF, null, 0);
+        for (0..count) |i| {
+            const len = w.DragQueryFileW(hdrop, @intCast(i), null, 0);
+            const buf = internal.allocator.alloc(u16, len + 1) catch continue;
+            defer internal.allocator.free(buf);
+            _ = w.DragQueryFileW(hdrop, @intCast(i), buf.ptr, len + 1);
+            const path = std.unicode.utf16LeToUtf8Alloc(internal.allocator, buf[0..len]) catch continue;
+            window.events.push(.{ .drop_file = path });
+        }
+    }
+
+    fn extractText(window: *Window, data: *w.IDataObject) void {
+        var fmt = makeFormatEtc(w.CF_UNICODETEXT);
+        var medium: w.STGMEDIUM = undefined;
+        if (data.GetData(&fmt, &medium) != w.S_OK) return;
+        defer w.ReleaseStgMedium(&medium);
+        const ptr: [*:0]u16 = @ptrCast(@alignCast(w.GlobalLock(medium.u.hGlobal) orelse return));
+        defer _ = w.GlobalUnlock(medium.u.hGlobal);
+        const wstr = std.mem.sliceTo(ptr, 0);
+        if (std.unicode.utf16LeToUtf8Alloc(internal.allocator, wstr)) |text| {
+            window.events.push(.{ .drop_text = text });
+        } else |_| {}
+    }
+};
 
 fn logLastError(name: []const u8) error{Unexpected} {
     log.err("{s} failed, error {}", .{ name, w.GetLastError() });

--- a/src/win32.zig
+++ b/src/win32.zig
@@ -370,9 +370,14 @@ pub const Window = struct {
     text: bool = false,
     opengl: if (build_options.opengl) struct { dc: w.HDC = null, rc: w.HGLRC = null } else struct {} = .{},
     drop_target: DropTarget = undefined,
+    drop_files: std.ArrayListUnmanaged([]const u8) = .empty,
+    drop_text: ?[]const u8 = null,
 
     pub fn destroy(self: *Window) void {
         _ = w.RevokeDragDrop(self.window);
+        for (self.drop_files.items) |f| internal.allocator.free(f);
+        self.drop_files.deinit(internal.allocator);
+        if (self.drop_text) |t| internal.allocator.free(t);
         if (build_options.opengl) {
             _ = w.wglDeleteContext(self.opengl.rc);
             _ = w.ReleaseDC(self.window, self.opengl.dc);
@@ -386,6 +391,10 @@ pub const Window = struct {
 
     pub fn getEvent(self: *Window) ?wio.Event {
         return self.events.pop();
+    }
+
+    pub fn getDropData(self: *Window) wio.DropData {
+        return .{ .files = self.drop_files.items, .text = self.drop_text };
     }
 
     pub fn enableTextInput(self: *Window, _: wio.TextInputOptions) void {
@@ -1257,6 +1266,10 @@ const DropTarget = struct {
         dt.has_text = data_obj.QueryGetData(&fmt) == w.S_OK;
         if (dt.has_files or dt.has_text) {
             effect.* = w.DROPEFFECT_COPY;
+            for (dt.window.drop_files.items) |f| internal.allocator.free(f);
+            dt.window.drop_files.clearRetainingCapacity();
+            if (dt.window.drop_text) |t| internal.allocator.free(t);
+            dt.window.drop_text = null;
             dt.window.events.push(.drop_begin);
             pushPosition(dt.window, pt);
         } else {
@@ -1308,7 +1321,7 @@ const DropTarget = struct {
             defer internal.allocator.free(buf);
             _ = w.DragQueryFileW(hdrop, @intCast(i), buf.ptr, len + 1);
             const path = std.unicode.utf16LeToUtf8Alloc(internal.allocator, buf[0..len]) catch continue;
-            window.events.push(.{ .drop_file = path });
+            window.drop_files.append(internal.allocator, path) catch {};
         }
     }
 
@@ -1321,7 +1334,7 @@ const DropTarget = struct {
         defer _ = w.GlobalUnlock(medium.u.hGlobal);
         const wstr = std.mem.sliceTo(ptr, 0);
         if (std.unicode.utf16LeToUtf8Alloc(internal.allocator, wstr)) |text| {
-            window.events.push(.{ .drop_text = text });
+            window.drop_text = text;
         } else |_| {}
     }
 };

--- a/src/win32.zig
+++ b/src/win32.zig
@@ -393,8 +393,8 @@ pub const Window = struct {
         return self.events.pop();
     }
 
-    pub fn getDropData(self: *Window) wio.DropData {
-        return .{ .files = self.drop_files.items, .text = self.drop_text };
+    pub fn getDropData(self: *Window, allocator: std.mem.Allocator) wio.DropData {
+        return wio.DropData.dupe(allocator, self.drop_files.items, self.drop_text) catch .{ .files = &.{}, .text = null };
     }
 
     pub fn enableTextInput(self: *Window, _: wio.TextInputOptions) void {

--- a/src/wio.zig
+++ b/src/wio.zig
@@ -432,8 +432,12 @@ pub const Event = union(enum) {
     touch: struct { id: u8, x: u16, y: u16 },
     touch_end: struct { id: u8, ignore: bool },
 
+    drop_begin: void,
+    drop_position: Position,
     /// Allocated with the allocator passed to `init()`. Caller must free.
     drop_file: []const u8,
+    /// Allocated with the allocator passed to `init()`. Caller must free.
+    drop_text: []const u8,
     drop_complete: void,
 };
 

--- a/src/wio.zig
+++ b/src/wio.zig
@@ -80,6 +80,11 @@ pub fn getModifiers() Modifiers {
     return backend.getModifiers();
 }
 
+pub const DropData = struct {
+    files: []const []const u8,
+    text: ?[]const u8,
+};
+
 pub const Modifiers = struct {
     control: bool = false,
     shift: bool = false,
@@ -184,6 +189,10 @@ pub const Window = struct {
 
     pub fn setClipboardText(self: *Window, text: []const u8) void {
         self.backend.setClipboardText(text);
+    }
+
+    pub fn getDropData(self: *Window) DropData {
+        return self.backend.getDropData();
     }
 
     pub fn getClipboardText(self: *Window, allocator: std.mem.Allocator) ?[]u8 {
@@ -434,10 +443,6 @@ pub const Event = union(enum) {
 
     drop_begin: void,
     drop_position: Position,
-    /// Allocated with the allocator passed to `init()`. Caller must free.
-    drop_file: []const u8,
-    /// Allocated with the allocator passed to `init()`. Caller must free.
-    drop_text: []const u8,
     drop_complete: void,
 };
 

--- a/src/wio.zig
+++ b/src/wio.zig
@@ -431,6 +431,10 @@ pub const Event = union(enum) {
 
     touch: struct { id: u8, x: u16, y: u16 },
     touch_end: struct { id: u8, ignore: bool },
+
+    /// Allocated with the allocator passed to `init()`. Caller must free.
+    drop_file: []const u8,
+    drop_complete: void,
 };
 
 pub const EventType = @typeInfo(Event).@"union".tag_type.?;

--- a/src/wio.zig
+++ b/src/wio.zig
@@ -83,6 +83,26 @@ pub fn getModifiers() Modifiers {
 pub const DropData = struct {
     files: []const []const u8,
     text: ?[]const u8,
+
+    pub fn dupe(allocator: std.mem.Allocator, files: []const []const u8, text: ?[]const u8) !DropData {
+        const out = try allocator.alloc([]const u8, files.len);
+        var n: usize = 0;
+        errdefer {
+            for (out[0..n]) |f| allocator.free(f);
+            allocator.free(out);
+        }
+        for (files) |f| {
+            out[n] = try allocator.dupe(u8, f);
+            n += 1;
+        }
+        return .{ .files = out, .text = if (text) |t| try allocator.dupe(u8, t) else null };
+    }
+
+    pub fn free(self: DropData, allocator: std.mem.Allocator) void {
+        for (self.files) |f| allocator.free(f);
+        allocator.free(self.files);
+        if (self.text) |t| allocator.free(t);
+    }
 };
 
 pub const Modifiers = struct {
@@ -191,8 +211,8 @@ pub const Window = struct {
         self.backend.setClipboardText(text);
     }
 
-    pub fn getDropData(self: *Window) DropData {
-        return self.backend.getDropData();
+    pub fn getDropData(self: *Window, allocator: std.mem.Allocator) DropData {
+        return self.backend.getDropData(allocator);
     }
 
     pub fn getClipboardText(self: *Window, allocator: std.mem.Allocator) ?[]u8 {


### PR DESCRIPTION
Add drag-and-drop support

 Implements `drop_begin`, `drop_position`, `drop_file`, `drop_text`, and `drop_complete` events.
 
| Platform | Status |
| :--- | :--- |
| **Linux** | Working |
| **Windows** | Working |
| **MacOS** | Not Implemented |
| **WebAssembly** | Working |
| **Haiku** | Working |