### PR TITLE
macos: add mouse_enter event and fix tracking during drag

### DIFF
--- a/src/macos.m
+++ b/src/macos.m
@@ -19,6 +19,7 @@ extern void wioButtonRelease(void *, UInt8);
 extern void wioMouse(void *, UInt16, UInt16);
 extern void wioMouseRelative(void *, SInt16, SInt16);
 extern void wioMouseLeave(void *);
+extern void wioMouseEnter(void *);
 extern void wioScroll(void *, Float32, Float32);
 extern char *wioDupeClipboardText(const void *, const char *, size_t *);
 
@@ -262,7 +263,7 @@ static void warpCursor(NSWindow *window) {
     [self removeTrackingArea:area];
     area = [[NSTrackingArea alloc]
         initWithRect:[self frame]
-        options:NSTrackingActiveInKeyWindow | NSTrackingCursorUpdate | NSTrackingMouseEnteredAndExited
+        options:NSTrackingActiveInKeyWindow | NSTrackingCursorUpdate | NSTrackingMouseEnteredAndExited | NSTrackingEnabledDuringMouseDrag
         owner:self
         userInfo:nil];
     [self addTrackingArea:area];
@@ -343,21 +344,40 @@ static void warpCursor(NSWindow *window) {
     wioMouse(zig, location.x, location.y);
 }
 
+- (void)trackDragBoundary:(NSEvent *)event {
+    NSPoint location = [event locationInWindow];
+    NSRect frame = [self frame];
+    BOOL inside = location.x >= 0 && location.y >= 0 && location.x <= frame.size.width && location.y <= frame.size.height;
+    if (inside && !cursorInside) {
+        if (cursorMode != 0) [NSCursor hide];
+        cursorInside = YES;
+        wioMouseEnter(zig);
+    } else if (!inside && cursorInside) {
+        wioMouseLeave(zig);
+        if (cursorMode != 0) [NSCursor unhide];
+        cursorInside = NO;
+    }
+}
+
 - (void)mouseDragged:(NSEvent *)event {
+    [self trackDragBoundary:event];
     [self mouseMoved:event];
 }
 
 - (void)rightMouseDragged:(NSEvent *)event {
+    [self trackDragBoundary:event];
     [self mouseMoved:event];
 }
 
 - (void)otherMouseDragged:(NSEvent *)event {
+    [self trackDragBoundary:event];
     [self mouseMoved:event];
 }
 
 - (void)mouseEntered:(NSEvent *)event {
     if (!cursorInside && cursorMode != 0) [NSCursor hide];
     cursorInside = YES;
+    wioMouseEnter(zig);
 }
 
 - (void)mouseExited:(NSEvent *)event {

--- a/src/macos.zig
+++ b/src/macos.zig
@@ -860,6 +860,10 @@ export fn wioMouseLeave(self: *Window) void {
     self.events.push(.mouse_leave);
 }
 
+export fn wioMouseEnter(self: *Window) void {
+    self.events.push(.mouse_enter);
+}
+
 export fn wioScroll(self: *Window, x: f32, y: f32) void {
     if (x != 0) self.events.push(.{ .scroll_horizontal = x });
     if (y != 0) self.events.push(.{ .scroll_vertical = -y });

--- a/src/wio.zig
+++ b/src/wio.zig
@@ -431,6 +431,8 @@ pub const Event = union(enum) {
 
     touch: struct { id: u8, x: u16, y: u16 },
     touch_end: struct { id: u8, ignore: bool },
+
+    mouse_enter: void,
 };
 
 pub const EventType = @typeInfo(Event).@"union".tag_type.?;


### PR DESCRIPTION
On macOS, mouseEntered:/mouseExited: tracking callbacks were not delivered while a mouse button was held down. Add
NSTrackingEnabledDuringMouseDrag and, as a belt-and-braces fix for cases where that flag alone is insufficient, synthesize enter/leave transitions from mouseDragged:/rightMouseDragged:/otherMouseDragged: by comparing the event location against the view bounds and firing wioMouseEnter/wioMouseLeave on state change.

Also add a new mouse_enter Event variant and the matching wioMouseEnter export, mirroring the existing mouse_leave plumbing.