### PR TITLE
win32: explictly discard return value of wglDeleteContext

### DIFF
--- a/src/win32.zig
+++ b/src/win32.zig
@@ -647,7 +647,7 @@ pub const GlContext = struct {
     rc: w.HGLRC,
 
     pub fn destroy(self: *GlContext) void {
-        w.wglDeleteContext(self.rc);
+        _ = w.wglDeleteContext(self.rc);
     }
 };
 


### PR DESCRIPTION
Explictly discard return value of wglDeleteContext on win32 (it returns a i32).
Fixes build error on win32 + OpenGL:
```sh
zig-pkg\wio-0.0.0-8xHrr-geBwAaZ-XjLiDJ0-ACOzMgD1cl7VCQpOq2gzNF\src\win32.zig:650:27: error: value of type 'i32' ignored
        w.wglDeleteContext(self.rc);
        ~~~~~~~~~~~~~~~~~~^~~~~~~~~
zig-pkg\wio-0.0.0-8xHrr-geBwAaZ-XjLiDJ0-ACOzMgD1cl7VCQpOq2gzNF\src\win32.zig:650:27: note: all non-void values must be used
zig-pkg\wio-0.0.0-8xHrr-geBwAaZ-XjLiDJ0-ACOzMgD1cl7VCQpOq2gzNF\src\win32.zig:650:27: note: to discard the value, assign it to '_'
```
Weirdly, the build error only occurs when I consume wio in my project, but not when I build the wio demo from wio itself.