### PR TITLE
android: add density fallback for API levels <34

### DIFF
--- a/src/android/WioActivity.java
+++ b/src/android/WioActivity.java
@@ -135,7 +135,14 @@ public class WioActivity extends Activity implements SurfaceHolder.Callback, OnG
 
     @Override
     public void surfaceChanged(SurfaceHolder holder, int format, int width, int height) {
-        float density = getWindowManager().getCurrentWindowMetrics().getDensity();
+        float density;
+        try {
+            density = getWindowManager().getCurrentWindowMetrics().getDensity();
+        } catch (java.lang.NoSuchMethodError ignored) {
+            // WindowMetrics.getDensity was added in API level 34.
+            // Prior to that, DisplayMetrics can be used as a fallback.
+            density = getResources().getDisplayMetrics().density;
+        }
         surfaceChangedNative(density, width, height);
     }
 

--- a/src/android/WioActivity.java
+++ b/src/android/WioActivity.java
@@ -135,14 +135,12 @@ public class WioActivity extends Activity implements SurfaceHolder.Callback, OnG
 
     @Override
     public void surfaceChanged(SurfaceHolder holder, int format, int width, int height) {
-        float density;
-        try {
-            density = getWindowManager().getCurrentWindowMetrics().getDensity();
-        } catch (java.lang.NoSuchMethodError ignored) {
-            // WindowMetrics.getDensity was added in API level 34.
-            // Prior to that, DisplayMetrics can be used as a fallback.
-            density = getResources().getDisplayMetrics().density;
-        }
+        // In Android API level 34, `WindowMetrics.getDensity` was added.
+        // The documentation says that UI layout should use `WindowMetrics`,
+        // not `DisplayMetrics`, and that only the DPI of `DisplayMetrics` should
+        // be used. As of 0d5e37e, `WindowMetrics.getDensity` and
+        // `DisplayMetrics.density` result in identical values.
+        float density = getResources().getDisplayMetrics().density;
         surfaceChangedNative(density, width, height);
     }
 


### PR DESCRIPTION
`WindowMetrics.getDensity` was added in API level 34. Prior to that, `DisplayMetrics` can be used as a fallback. This is necessary for wio to work on these platforms.