### PR TITLE
android: declare 26 the minimum SDK version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,12 +71,12 @@ jobs:
       uses: android-actions/setup-android@v4
       with:
         packages: "build-tools;37.0.0 ndk;29.0.14206865 platforms;android-26"
-    - name: Build demo for API level 26
+    - name: Build demo
       working-directory: demo
       run: zig build -Dandroid=true -Dandroid_api_level=android8
-    - name: Build framebuffer example for API level 26
+    - name: Build framebuffer example
       working-directory: examples/framebuffer
       run: zig build -Dandroid=true -Dandroid_api_level=android8
-    - name: Build Vulkan example for API level 26
+    - name: Build Vulkan example
       working-directory: examples/vulkan
       run: zig build -Dandroid=true -Dandroid_api_level=android8

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
     - name: Set up Android SDK
       uses: android-actions/setup-android@v4
       with:
-        packages: "build-tools;37.0.0 ndk;29.0.14206865 platforms;android-35"
+        packages: "build-tools;37.0.0 ndk;29.0.14206865 platforms;android-35 platforms;android-26"
     - name: Build demo
       working-directory: demo
       run: zig build -Dandroid=true
@@ -80,3 +80,12 @@ jobs:
     - name: Build Vulkan example
       working-directory: examples/vulkan
       run: zig build -Dandroid=true
+    - name: Build demo for API level 26
+      working-directory: demo
+      run: zig build -Dandroid=true -Dandroid_api_level=android8
+    - name: Build framebuffer example for API level 26
+      working-directory: examples/framebuffer
+      run: zig build -Dandroid=true -Dandroid_api_level=android8
+    - name: Build Vulkan example for API level 26
+      working-directory: examples/vulkan
+      run: zig build -Dandroid=true -Dandroid_api_level=android8

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,16 +70,7 @@ jobs:
     - name: Set up Android SDK
       uses: android-actions/setup-android@v4
       with:
-        packages: "build-tools;37.0.0 ndk;29.0.14206865 platforms;android-35 platforms;android-26"
-    - name: Build demo
-      working-directory: demo
-      run: zig build -Dandroid=true
-    - name: Build framebuffer example
-      working-directory: examples/framebuffer
-      run: zig build -Dandroid=true
-    - name: Build Vulkan example
-      working-directory: examples/vulkan
-      run: zig build -Dandroid=true
+        packages: "build-tools;37.0.0 ndk;29.0.14206865 platforms;android-26"
     - name: Build demo for API level 26
       working-directory: demo
       run: zig build -Dandroid=true -Dandroid_api_level=android8

--- a/README.md
+++ b/README.md
@@ -153,6 +153,8 @@ file should contain `comptime { _ = wio; }` at the top level.
 
 [demo/build.zig][7] is an example of a build script supporting Android.
 
+Android API levels 26 (Android 8) to 36 (Android 16) are currently supported.
+
 ### WebAssembly
 
 If OpenGL is enabled, wio imports `createContext` and `makeContextCurrent`

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Actively tested:
 - Windows
 - macOS (10.13+)
 - Linux
-- Android
+- Android (API 26+ / Android 8 and up)
 - WebAssembly
 
 Not actively tested, but most code is shared with Linux:
@@ -152,8 +152,6 @@ To ensure the entry point is exported from the shared library, the root source
 file should contain `comptime { _ = wio; }` at the top level.
 
 [demo/build.zig][7] is an example of a build script supporting Android.
-
-Android API levels 26 (Android 8) to 36 (Android 16) are currently supported.
 
 ### WebAssembly
 

--- a/demo/src/android/AndroidManifest.xml
+++ b/demo/src/android/AndroidManifest.xml
@@ -3,6 +3,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     package="net.tiredsleepy.wio.demo">
     <uses-sdk android:minSdkVersion="26" android:targetSdkVersion="36" />
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <application
         android:label="@string/app_name">
         <activity
@@ -15,5 +16,4 @@
             </intent-filter>
         </activity>
     </application>
-    <uses-permission android:name="android.permission.RECORD_AUDIO" />
 </manifest>

--- a/demo/src/android/AndroidManifest.xml
+++ b/demo/src/android/AndroidManifest.xml
@@ -15,4 +15,5 @@
         </activity>
     </application>
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
+    <uses-sdk android:minSdkVersion="26" />
 </manifest>

--- a/demo/src/android/AndroidManifest.xml
+++ b/demo/src/android/AndroidManifest.xml
@@ -2,6 +2,7 @@
 <manifest
     xmlns:android="http://schemas.android.com/apk/res/android"
     package="net.tiredsleepy.wio.demo">
+    <uses-sdk android:minSdkVersion="26" android:targetSdkVersion="36" />
     <application
         android:label="@string/app_name">
         <activity
@@ -15,5 +16,4 @@
         </activity>
     </application>
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
-    <uses-sdk android:minSdkVersion="26" />
 </manifest>

--- a/examples/framebuffer/src/android/AndroidManifest.xml
+++ b/examples/framebuffer/src/android/AndroidManifest.xml
@@ -14,4 +14,5 @@
             </intent-filter>
         </activity>
     </application>
+    <uses-sdk android:minSdkVersion="26" />
 </manifest>

--- a/examples/framebuffer/src/android/AndroidManifest.xml
+++ b/examples/framebuffer/src/android/AndroidManifest.xml
@@ -2,6 +2,7 @@
 <manifest
     xmlns:android="http://schemas.android.com/apk/res/android"
     package="net.tiredsleepy.wio.framebuffer">
+    <uses-sdk android:minSdkVersion="26" android:targetSdkVersion="36" />
     <application
         android:label="@string/app_name">
         <activity
@@ -14,5 +15,4 @@
             </intent-filter>
         </activity>
     </application>
-    <uses-sdk android:minSdkVersion="26" />
 </manifest>

--- a/examples/vulkan/src/android/AndroidManifest.xml
+++ b/examples/vulkan/src/android/AndroidManifest.xml
@@ -2,6 +2,7 @@
 <manifest
     xmlns:android="http://schemas.android.com/apk/res/android"
     package="net.tiredsleepy.wio.vulkan">
+    <uses-sdk android:minSdkVersion="26" android:targetSdkVersion="36" />
     <application
         android:label="@string/app_name">
         <activity
@@ -14,5 +15,4 @@
             </intent-filter>
         </activity>
     </application>
-    <uses-sdk android:minSdkVersion="26" />
 </manifest>

--- a/examples/vulkan/src/android/AndroidManifest.xml
+++ b/examples/vulkan/src/android/AndroidManifest.xml
@@ -14,4 +14,5 @@
             </intent-filter>
         </activity>
     </application>
+    <uses-sdk android:minSdkVersion="26" />
 </manifest>

--- a/src/android/WioActivity.java
+++ b/src/android/WioActivity.java
@@ -135,7 +135,14 @@ public class WioActivity extends Activity implements SurfaceHolder.Callback, OnG
 
     @Override
     public void surfaceChanged(SurfaceHolder holder, int format, int width, int height) {
-        float density = getWindowManager().getCurrentWindowMetrics().getDensity();
+        float density;
+        try {
+            density = getWindowManager().getCurrentWindowMetrics().getDensity();
+        } catch (java.lang.NoSuchMethodError ignored) {
+            // WindowMetrics.getDensity was added in API level 34.
+            // Prior to that, DisplayMetrics can be used as a fallback.
+            density = getResources().getDisplayMetrics().density;
+        }
         surfaceChangedNative(density, width, height);
     }
 

--- a/src/android/WioActivity.java
+++ b/src/android/WioActivity.java
@@ -135,14 +135,12 @@ public class WioActivity extends Activity implements SurfaceHolder.Callback, OnG
 
     @Override
     public void surfaceChanged(SurfaceHolder holder, int format, int width, int height) {
-        float density;
-        try {
-            density = getWindowManager().getCurrentWindowMetrics().getDensity();
-        } catch (java.lang.NoSuchMethodError ignored) {
-            // WindowMetrics.getDensity was added in API level 34.
-            // Prior to that, DisplayMetrics can be used as a fallback.
-            density = getResources().getDisplayMetrics().density;
-        }
+        // In Android API level 34, `WindowMetrics.getDensity` was added.
+        // The documentation says that UI layout should use `WindowMetrics`,
+        // not `DisplayMetrics`, and that only the DPI of `DisplayMetrics` should
+        // be used. As of 0d5e37e, `WindowMetrics.getDensity` and
+        // `DisplayMetrics.density` result in identical values.
+        float density = getResources().getDisplayMetrics().density;
         surfaceChangedNative(density, width, height);
     }
 


### PR DESCRIPTION
This PR is on top of #23 and adds CI and documentation for 26 as the minimum SDK version.