### PR TITLE
update comptime field access to work on master 0.17.0-dev.1683+5ceec001b

### DIFF
--- a/src/unix/DynLib.zig
+++ b/src/unix/DynLib.zig
@@ -51,7 +51,7 @@ pub fn load(c: anytype, comptime libs: []const Lib) !void {
         succeeded += 1;
     }
 
-    const names = std.meta.fieldNames(@TypeOf(c.*));
+    const names = comptime std.meta.fieldNames(@TypeOf(c.*));
     const table: *[names.len]?*const fn () void = @ptrCast(c);
     for (names, table) |name, *out| {
         for (libs) |lib| {

--- a/src/unix/x11.zig
+++ b/src/unix/x11.zig
@@ -114,7 +114,7 @@ var atoms: blk: {
         "text/plain;charset=utf-8",
     } else .{};
     const types: [names.len]type = @splat(h.Atom);
-    const attrs: [names.len]std.builtin.Type.StructField.Attributes = @splat(.{});
+    const attrs: [names.len]std.builtin.Type.Struct.FieldAttributes = @splat(.{});
     break :blk @Struct(.@"extern", null, &names, &types, &attrs);
 } = undefined;
 
@@ -162,9 +162,9 @@ pub fn init() !bool {
     try unix.pollfds.append(internal.allocator, .{ .fd = h.ConnectionNumber(globals.display), .events = std.c.POLL.IN, .revents = undefined });
 
     var atom_names = comptime blk: {
-        const fields = @typeInfo(@TypeOf(atoms)).@"struct".fields;
+        const fields = @typeInfo(@TypeOf(atoms)).@"struct".field_names;
         var atom_names: [fields.len][*:0]const u8 = undefined;
-        for (&atom_names, fields) |*name, field| name.* = field.name;
+        for (&atom_names, fields) |*name, field| name.* = field;
         break :blk atom_names;
     };
     _ = c.XInternAtoms(globals.display, @ptrCast(&atom_names), atom_names.len, h.False, @ptrCast(&atoms));


### PR DESCRIPTION
On current zig master: 0.17.0-dev.1683+5ceec001b

The minimal example fails to compile on linux using wayland:
```
zig-pkg/wio-0.0.0-8xHrr79VCABN3bQ1Q9XrQScWkAXvL8HCXjJ3iXU4jHtL/src/unix/DynLib.zig:55:25: error: unable to evaluate comptime expression
    const table: *[names.len]?*const fn () void = @ptrCast(c);
                   ~~~~~^~~~
zig-pkg/wio-0.0.0-8xHrr79VCABN3bQ1Q9XrQScWkAXvL8HCXjJ3iXU4jHtL/src/unix/DynLib.zig:55:25: note: types must be comptime-known
referenced by:
    init: zig-pkg/wio-0.0.0-8xHrr79VCABN3bQ1Q9XrQScWkAXvL8HCXjJ3iXU4jHtL/src/unix/wayland.zig:158:16
    init: zig-pkg/wio-0.0.0-8xHrr79VCABN3bQ1Q9XrQScWkAXvL8HCXjJ3iXU4jHtL/src/unix.zig:67:37
```