### PR TITLE
lean-deps: drop bundled wio_macos_sdk

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -81,12 +81,6 @@ pub fn build(b: *std.Build) !void {
         .macos => {
             module.addCSourceFile(.{ .file = b.path("src/macos.m"), .flags = &.{ "-fobjc-arc", "-Wno-deprecated-declarations" } });
 
-            if (b.lazyDependency("wio_macos_sdk", .{})) |macos_sdk| {
-                module.addSystemFrameworkPath(macos_sdk.path("System/Library/Frameworks"));
-                module.addSystemIncludePath(macos_sdk.path("usr/include"));
-                module.addLibraryPath(macos_sdk.path("usr/lib"));
-            }
-
             module.linkFramework("Cocoa", .{});
             if (enable_vulkan) {
                 module.linkFramework("QuartzCore", .{});

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -9,11 +9,6 @@
             .hash = "win32-0.0.0-4XUuba3r_gIzIdDxDJM72L90Kf4kTUI1mAqYjE-llhAZ",
             .lazy = true,
         },
-        .wio_macos_sdk = .{
-            .url = "https://github.com/ypsvlq/wio-macos-sdk/archive/1014fff9b544bf80200a2a9a92af257451286913.tar.gz",
-            .hash = "wio_macos_sdk-15.5.0-Q4Y7wxqRsAE1ifcDVRYPyFChElssvep3qd5-A_fPS5Jp",
-            .lazy = true,
-        },
         .wio_unix_headers = .{
             .url = "https://github.com/ypsvlq/wio-unix-headers/archive/3bd227608c8fc7e4cd8547e43966b60f81c4caf3.tar.gz",
             .hash = "wio_unix_headers-0.0.0-seffXF_FQQC9vaRGpzc1-w6M8YktDc2qzlOgItxv6kWO",


### PR DESCRIPTION
bundling macos sdks is illegal and bad practice because it leads to duplication in bigger software projects (bundling binaries in general is problematic).
see https://github.com/david-vanderson/dvui/pull/975